### PR TITLE
Add Terraform infrastructure and CI/CD for JOTIQ

### DIFF
--- a/.github/workflows/build-deploy-ecs.yml
+++ b/.github/workflows/build-deploy-ecs.yml
@@ -1,0 +1,121 @@
+name: Build and Deploy ECS Services
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [dev, staging, prod]
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      IMAGE_TAG: ${{ github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Determine account ID
+        id: account
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+          echo "account_id=$ACCOUNT_ID" >> $GITHUB_OUTPUT
+
+      - name: Build and push API image
+        run: |
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          API_REPO=jotiq-${{ matrix.environment }}-api
+          docker build -t $ECR_REGISTRY/$API_REPO:${IMAGE_TAG} -f api/Dockerfile api
+          docker push $ECR_REGISTRY/$API_REPO:${IMAGE_TAG}
+
+      - name: Build and push Web image
+        run: |
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          WEB_REPO=jotiq-${{ matrix.environment }}-web
+          docker build -t $ECR_REGISTRY/$WEB_REPO:${IMAGE_TAG} -f web/Dockerfile web
+          docker push $ECR_REGISTRY/$WEB_REPO:${IMAGE_TAG}
+
+      - name: Build and push Worker image
+        run: |
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          WORKER_REPO=jotiq-${{ matrix.environment }}-worker
+          docker build -t $ECR_REGISTRY/$WORKER_REPO:${IMAGE_TAG} -f worker/Dockerfile worker
+          docker push $ECR_REGISTRY/$WORKER_REPO:${IMAGE_TAG}
+
+      - name: Register updated API task definition
+        id: api_task
+        run: |
+          FAMILY=jotiq-${{ matrix.environment }}-api
+          CONTAINER_NAME=${FAMILY}-container
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          IMAGE=$ECR_REGISTRY/jotiq-${{ matrix.environment }}-api:${IMAGE_TAG}
+          aws ecs describe-task-definition --task-definition $FAMILY --query 'taskDefinition' > base.json
+          cat base.json | jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' > stripped.json
+          cat stripped.json | jq '.containerDefinitions |= map(if .name == "'"${CONTAINER_NAME}"'" then .image = "'"${IMAGE}"'" else . end)' > updated.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://updated.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
+          rm -f base.json stripped.json updated.json
+
+      - name: Register updated Web task definition
+        id: web_task
+        run: |
+          FAMILY=jotiq-${{ matrix.environment }}-web
+          CONTAINER_NAME=${FAMILY}-container
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          IMAGE=$ECR_REGISTRY/jotiq-${{ matrix.environment }}-web:${IMAGE_TAG}
+          aws ecs describe-task-definition --task-definition $FAMILY --query 'taskDefinition' > base.json
+          cat base.json | jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' > stripped.json
+          cat stripped.json | jq '.containerDefinitions |= map(if .name == "'"${CONTAINER_NAME}"'" then .image = "'"${IMAGE}"'" else . end)' > updated.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://updated.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
+          rm -f base.json stripped.json updated.json
+
+      - name: Register updated Worker task definition
+        id: worker_task
+        run: |
+          FAMILY=jotiq-${{ matrix.environment }}-worker
+          CONTAINER_NAME=${FAMILY}-container
+          ECR_REGISTRY=${{ steps.account.outputs.account_id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          IMAGE=$ECR_REGISTRY/jotiq-${{ matrix.environment }}-worker:${IMAGE_TAG}
+          aws ecs describe-task-definition --task-definition $FAMILY --query 'taskDefinition' > base.json
+          cat base.json | jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' > stripped.json
+          cat stripped.json | jq '.containerDefinitions |= map(if .name == "'"${CONTAINER_NAME}"'" then .image = "'"${IMAGE}"'" else . end)' > updated.json
+          TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://updated.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "arn=$TASK_DEF_ARN" >> $GITHUB_OUTPUT
+          rm -f base.json stripped.json updated.json
+
+      - name: Trigger API deployment
+        run: |
+          CLUSTER=jotiq-${{ matrix.environment }}
+          SERVICE=jotiq-${{ matrix.environment }}-api
+          aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition ${{ steps.api_task.outputs.arn }} --force-new-deployment
+
+      - name: Trigger Web deployment
+        run: |
+          CLUSTER=jotiq-${{ matrix.environment }}
+          SERVICE=jotiq-${{ matrix.environment }}-web
+          aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition ${{ steps.web_task.outputs.arn }} --force-new-deployment
+
+      - name: Trigger Worker deployment
+        run: |
+          CLUSTER=jotiq-${{ matrix.environment }}
+          SERVICE=jotiq-${{ matrix.environment }}-worker
+          aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition ${{ steps.worker_task.outputs.arn }} --force-new-deployment

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -1,0 +1,70 @@
+name: Terraform Plan & Apply
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terraform:
+    name: Terraform ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [dev, staging, prod]
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      TF_STATE_BUCKET: ${{ secrets.TF_STATE_BUCKET }}
+      TF_STATE_LOCK_TABLE: ${{ secrets.TF_STATE_LOCK_TABLE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Fmt
+        run: terraform -chdir=infra/terraform/envs/${{ matrix.env }} fmt -check
+
+      - name: Terraform Init
+        run: >-
+          terraform -chdir=infra/terraform/envs/${{ matrix.env }} init
+          -backend-config="bucket=${{ env.TF_STATE_BUCKET }}"
+          -backend-config="key=${{ matrix.env }}/terraform.tfstate"
+          -backend-config="dynamodb_table=${{ env.TF_STATE_LOCK_TABLE }}"
+          -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform Validate
+        run: terraform -chdir=infra/terraform/envs/${{ matrix.env }} validate
+
+      - name: Terraform Plan
+        run: terraform -chdir=infra/terraform/envs/${{ matrix.env }} plan -out=tfplan
+
+      - name: Upload plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan-${{ matrix.env }}
+          path: infra/terraform/envs/${{ matrix.env }}/tfplan
+
+      - name: Terraform Apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: terraform -chdir=infra/terraform/envs/${{ matrix.env }} apply -auto-approve tfplan
+        environment:
+          name: terraform-${{ matrix.env }}

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,27 @@
+SHELL := /bin/bash
+TF_DIR ?= infra/terraform/envs/$(ENV)
+ENV ?= dev
+
+.PHONY: fmt validate plan apply destroy bootstrap init
+
+fmt:
+terraform -chdir=$(TF_DIR) fmt -recursive
+
+validate: init
+terraform -chdir=$(TF_DIR) validate
+
+plan: init
+terraform -chdir=$(TF_DIR) plan
+
+apply: init
+terraform -chdir=$(TF_DIR) apply -auto-approve
+
+destroy: init
+terraform -chdir=$(TF_DIR) destroy -auto-approve
+
+init:
+terraform -chdir=$(TF_DIR) init
+
+bootstrap:
+terraform -chdir=infra/terraform/global/backend init
+terraform -chdir=infra/terraform/global/backend apply -auto-approve

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,112 @@
+# JOTIQ Infrastructure-as-Code
+
+This repository provisions the AWS infrastructure for the multi-tenant SaaS platform **JOTIQ** using Terraform and GitHub Actions. It follows a modular structure and supports the `dev`, `staging`, and `prod` environments.
+
+## Prerequisites
+
+1. **Tools**
+   - Terraform >= 1.5
+   - AWS CLI >= 2.13 with credentials that can provision the remote state resources
+   - Make
+2. **Remote State Resources** (create once per AWS account/region)
+   ```bash
+   aws s3api create-bucket \
+     --bucket <jotiq-terraform-state> \
+     --create-bucket-configuration LocationConstraint=<region>
+
+   aws s3api put-bucket-versioning \
+     --bucket <jotiq-terraform-state> \
+     --versioning-configuration Status=Enabled
+
+   aws dynamodb create-table \
+     --table-name <jotiq-terraform-locks> \
+     --attribute-definitions AttributeName=LockID,AttributeType=S \
+     --key-schema AttributeName=LockID,KeyType=HASH \
+     --billing-mode PAY_PER_REQUEST
+   ```
+
+3. **Certificates & DNS**
+   - Issue ACM certificates in the relevant regions:
+     - `us-east-1` for CloudFront (`assets.jotiq.com`).
+     - The environment region for ALB (`api.jotiq.com`, `app.jotiq.com`).
+   - Ensure Route53 hosted zones exist or provide existing hosted zone IDs.
+
+4. **GitHub OIDC IAM Role**
+   - Using the Terraform modules in this repo (`modules/iam_roles`), create a deploy role in the target account.
+   - Add the role ARN to the repository secret `AWS_OIDC_ROLE_ARN`.
+
+## Repository Layout
+
+```
+infra/
+  terraform/
+    global/        # Remote state bootstrap + org-wide security
+    modules/       # Reusable building blocks
+    envs/          # Environment compositions (dev, staging, prod)
+.github/workflows  # CI/CD pipelines
+```
+
+## Getting Started
+
+1. **Bootstrap Backend**
+   ```bash
+   cd infra/terraform/global/backend
+   terraform init -backend-config="bucket=<jotiq-terraform-state>" \
+                   -backend-config="key=global/backend/terraform.tfstate" \
+                   -backend-config="dynamodb_table=<jotiq-terraform-locks>" \
+                   -backend-config="region=<region>"
+   terraform workspace new default || true
+   terraform plan -out tfplan
+   terraform apply tfplan
+   ```
+
+   The backend configuration uses variables (`state_bucket`, `state_key_prefix`, `lock_table`, `region`) that can be passed via `-var` flags or `terraform.tfvars`.
+
+2. **Configure Environments**
+   For each environment (`dev`, `staging`, `prod`):
+   ```bash
+   cd infra/terraform/envs/<env>
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with environment-specific values.
+   terraform init -backend-config="bucket=<jotiq-terraform-state>" \
+                   -backend-config="key=<env>/terraform.tfstate" \
+                   -backend-config="dynamodb_table=<jotiq-terraform-locks>" \
+                   -backend-config="region=<region>"
+   terraform workspace new <env> || true
+   ```
+
+3. **Terraform Commands**
+   Use the provided Makefile wrappers from the repository root:
+   ```bash
+   make fmt
+   make validate ENV=<env>
+   make plan ENV=<env>
+   make apply ENV=<env>
+   ```
+   - `ENV` defaults to `dev` when not specified.
+   - `make bootstrap` runs the backend bootstrap in `infra/terraform/global/backend`.
+
+4. **GitHub Actions Pipelines**
+   - `terraform-plan-apply.yml` runs `fmt`, `validate`, and `plan` on pull requests and applies on pushes to `main` after manual approval.
+   - `build-deploy-ecs.yml` builds Docker images for the `api`, `web`, and `worker` services, pushes to ECR, and triggers CodeDeploy blue/green (for `api` and `web`) or rolling (for `worker`).
+
+## Outputs
+
+Key outputs produced per environment include:
+
+- ALB DNS name and Security Group IDs
+- ECS cluster and service names for `api`, `web`, and `worker`
+- CloudFront distribution domain for assets
+- SQS queue ARNs (primary and DLQ)
+- CloudWatch dashboard and alarm ARNs
+- SES domain identity ARNs and DKIM records
+
+These outputs appear after `terraform apply` and are consumed by CI/CD for deployments.
+
+## Notes
+
+- Secrets (e.g., `MONGODB_URI`, `JWT_SECRET`) are stored in AWS Secrets Manager and referenced by ECS task definitions via environment variables and secrets configuration.
+- MongoDB Atlas is managed separately. Terraform stores only the connection strings and credentials in Secrets Manager.
+- All S3 buckets enforce encryption at rest, block public access, and use lifecycle policies for cost optimization.
+- VPC endpoints minimize the need for NAT gateways when interacting with AWS services from private subnets.
+

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -1,0 +1,515 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  environment = var.environment
+  azs         = slice(data.aws_availability_zones.available.names, 0, 3)
+  tags = merge(var.default_tags, {
+    Project    = "JOTIQ"
+    Env        = local.environment
+  })
+  observability_services = [
+    {
+      name              = "api"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.api_cpu_alarm_threshold
+      memory_threshold  = var.api_memory_alarm_threshold
+    },
+    {
+      name              = "web"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.web_cpu_alarm_threshold
+      memory_threshold  = var.web_memory_alarm_threshold
+    },
+    {
+      name              = "worker"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.worker_cpu_alarm_threshold
+      memory_threshold  = var.worker_memory_alarm_threshold
+    }
+  ]
+}
+
+resource "aws_kms_key" "general" {
+  description         = "General purpose key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "general" {
+  name          = "alias/jotiq-${local.environment}-general"
+  target_key_id = aws_kms_key.general.key_id
+}
+
+resource "aws_kms_key" "sns" {
+  description         = "SNS encryption key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "sns" {
+  name          = "alias/jotiq-${local.environment}-sns"
+  target_key_id = aws_kms_key.sns.key_id
+}
+
+module "vpc" {
+  source     = "../../modules/vpc"
+  name       = "jotiq-${local.environment}"
+  cidr_block = var.vpc_cidr
+  azs        = local.azs
+  enable_nat = var.enable_nat_gateway
+  tags       = local.tags
+}
+
+module "endpoints" {
+  source                  = "../../modules/endpoints"
+  name                    = "jotiq-${local.environment}"
+  vpc_id                  = module.vpc.vpc_id
+  region                  = var.region
+  private_route_table_ids = module.vpc.private_route_table_ids
+  subnet_ids              = module.vpc.private_subnet_ids
+  allowed_cidrs           = [var.vpc_cidr]
+  tags                    = local.tags
+}
+
+module "secrets" {
+  source      = "../../modules/secrets"
+  project     = "jotiq"
+  environment = local.environment
+  tags        = local.tags
+}
+
+module "s3_logs" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-logs"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = null
+  tags       = local.tags
+}
+
+module "s3_assets" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-assets"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "assets"
+  tags       = local.tags
+}
+
+module "s3_backups" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-backups"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "backups"
+  tags       = local.tags
+}
+
+module "cloudfront" {
+  source                 = "../../modules/cloudfront_waf"
+  domain_name            = var.assets_domain
+  aliases                = [var.assets_domain]
+  s3_bucket_domain_name  = "${module.s3_assets.bucket_id}.s3.amazonaws.com"
+  acm_certificate_arn    = var.cloudfront_acm_certificate_arn
+  log_bucket_domain_name = "${module.s3_logs.bucket_id}.s3.amazonaws.com"
+  log_prefix             = "cloudfront"
+  web_acl_arn            = var.cloudfront_waf_arn
+  price_class            = var.cloudfront_price_class
+  tags                   = local.tags
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = module.s3_assets.bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontAccess"
+        Effect    = "Allow"
+        Principal = {
+          CanonicalUser = module.cloudfront.origin_access_identity_canonical_user_id
+        }
+        Action   = "s3:GetObject"
+        Resource = "${module.s3_assets.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic" "ses_feedback" {
+  name              = "jotiq-${local.environment}-ses-feedback"
+  kms_master_key_id = aws_kms_key.sns.arn
+  tags              = local.tags
+}
+
+module "ses_tx" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_transactional_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "ses_mkt" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_marketing_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "sqs_email_outbox" {
+  source                = "../../modules/sqs_queue"
+  name                  = "jotiq-${local.environment}-email-outbox"
+  kms_key_arn           = aws_kms_key.general.arn
+  visibility_timeout    = var.worker_visibility_timeout
+  retention_seconds     = var.sqs_retention_seconds
+  max_receive_count     = var.sqs_max_receive_count
+  tags                  = local.tags
+}
+
+module "ecr_api" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-api"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_web" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-web"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_worker" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-worker"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecs_cluster" {
+  source                  = "../../modules/ecs_cluster"
+  name                    = "jotiq-${local.environment}"
+  enable_container_insights = true
+  enable_fargate_spot     = var.enable_fargate_spot
+  tags                    = local.tags
+}
+
+module "alb" {
+  source                = "../../modules/alb"
+  name                  = "jotiq-${local.environment}-alb"
+  vpc_id                = module.vpc.vpc_id
+  subnet_ids            = module.vpc.public_subnet_ids
+  acm_certificate_arn   = var.alb_acm_certificate_arn
+  access_logs_bucket    = module.s3_logs.bucket_id
+  access_logs_prefix    = "alb"
+  tags                  = local.tags
+}
+
+locals {
+  alb_arn_suffix = element(split("loadbalancer/", module.alb.alb_arn), 1)
+  ses_records_map = merge(
+    {
+      tx_verification = {
+        name    = "_amazonses.${var.ses_transactional_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_tx.verification_token]
+      }
+    },
+    {
+      mkt_verification = {
+        name    = "_amazonses.${var.ses_marketing_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_mkt.verification_token]
+      }
+    },
+    {
+      tx_spf = {
+        name    = var.ses_transactional_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    {
+      mkt_spf = {
+        name    = var.ses_marketing_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    { for idx, token in module.ses_tx.dkim_tokens : "tx_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_transactional_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    },
+    { for idx, token in module.ses_mkt.dkim_tokens : "mkt_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_marketing_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    }
+  )
+}
+
+module "observability" {
+  source                = "../../modules/observability"
+  project               = "jotiq"
+  environment           = local.environment
+  services              = local.observability_services
+  log_kms_key_arn       = aws_kms_key.general.arn
+  sns_kms_key_arn       = aws_kms_key.sns.arn
+  alb_arn_suffix        = local.alb_arn_suffix
+  alb_latency_threshold = var.alb_latency_threshold
+  ecs_cluster_name      = module.ecs_cluster.cluster_name
+  sqs_queue_name        = module.sqs_email_outbox.queue_name
+  sqs_max_messages      = var.sqs_max_messages
+  sqs_max_age_seconds   = var.sqs_max_age_seconds
+  ses_identity          = var.ses_metrics_identity
+  ses_bounce_threshold    = var.ses_bounce_threshold
+  ses_complaint_threshold = var.ses_complaint_threshold
+  tags                  = local.tags
+}
+
+module "iam_roles" {
+  source         = "../../modules/iam_roles"
+  environment    = local.environment
+  log_group_arns = values(module.observability.log_group_arns)
+  secret_arns    = values(module.secrets.secret_arns)
+  s3_bucket_arns = [module.s3_assets.bucket_arn]
+  sqs_queue_arns = [module.sqs_email_outbox.queue_arn]
+  github_org     = var.github_org
+  github_repo    = var.github_repo
+  tags           = local.tags
+}
+
+resource "aws_security_group" "ecs_service" {
+  name        = "jotiq-${local.environment}-ecs-sg"
+  description = "Allow traffic from ALB"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description      = "App from ALB"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    security_groups  = [module.alb.security_group_id]
+  }
+
+  ingress {
+    description = "HTTPS egress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+locals {
+  api_log_group_name = module.observability.log_group_names["api"]
+  web_log_group_name = module.observability.log_group_names["web"]
+  worker_log_group_name = module.observability.log_group_names["worker"]
+  api_log_group_arn = module.observability.log_group_arns["api"]
+  web_log_group_arn = module.observability.log_group_arns["web"]
+  worker_log_group_arn = module.observability.log_group_arns["worker"]
+}
+
+module "ecs_service_api" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-api"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.api_image
+  cpu                = var.api_cpu
+  memory             = var.api_memory
+  desired_count      = var.api_desired_count
+  min_capacity       = var.api_min_capacity
+  max_capacity       = var.api_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 100
+  path_patterns      = ["/api/*"]
+  host_headers       = [var.api_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.api_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "JWT_SECRET", value_from = module.secrets.secret_arns["JWT_SECRET"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.api_log_group_name
+  log_group_arn      = local.api_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_5xx_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_web" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-web"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.web_image
+  cpu                = var.web_cpu
+  memory             = var.web_memory
+  desired_count      = var.web_desired_count
+  min_capacity       = var.web_min_capacity
+  max_capacity       = var.web_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 110
+  path_patterns      = ["/*"]
+  host_headers       = [var.app_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.web_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.web_log_group_name
+  log_group_arn      = local.web_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_latency_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_worker" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-worker"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.worker_image
+  cpu                = var.worker_cpu
+  memory             = var.worker_memory
+  desired_count      = var.worker_desired_count
+  min_capacity       = var.worker_min_capacity
+  max_capacity       = var.worker_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = ""
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.worker_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "SES_SMTP_USER", value_from = module.secrets.secret_arns["SES_SMTP_USER"] },
+    { name = "SES_SMTP_PASS", value_from = module.secrets.secret_arns["SES_SMTP_PASS"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.worker_log_group_name
+  log_group_arn      = local.worker_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = false
+  sqs_queue_metric = {
+    metric_name  = "ApproximateNumberOfMessagesVisible"
+    namespace    = "AWS/SQS"
+    statistic    = "Average"
+    unit         = "Count"
+    dimensions   = [{ name = "QueueName", value = module.sqs_email_outbox.queue_name }]
+    target_value = var.worker_queue_target
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "route53" {
+  source                    = "../../modules/route53"
+  create_zone               = var.create_hosted_zone
+  zone_name                 = var.domain
+  hosted_zone_id            = var.hosted_zone_id
+  api_record                = var.api_domain
+  app_record                = var.app_domain
+  assets_record             = var.assets_domain
+  alb_dns_name              = module.alb.alb_dns_name
+  alb_zone_id               = module.alb.alb_zone_id
+  cloudfront_domain_name    = module.cloudfront.distribution_domain_name
+  ses_records               = local.ses_records_map
+  tags = local.tags
+}
+
+resource "aws_ses_domain_identity_verification" "tx" {
+  domain     = var.ses_transactional_domain
+  depends_on = [module.route53]
+}
+
+resource "aws_ses_domain_identity_verification" "mkt" {
+  domain     = var.ses_marketing_domain
+  depends_on = [module.route53]
+}
+

--- a/infra/terraform/envs/dev/outputs.tf
+++ b/infra/terraform/envs/dev/outputs.tf
@@ -1,0 +1,49 @@
+output "alb_dns_name" {
+  description = "Application Load Balancer DNS name"
+  value       = module.alb.alb_dns_name
+}
+
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain"
+  value       = module.cloudfront.distribution_domain_name
+}
+
+output "api_service_name" {
+  description = "API ECS service name"
+  value       = module.ecs_service_api.service_name
+}
+
+output "web_service_name" {
+  description = "Web ECS service name"
+  value       = module.ecs_service_web.service_name
+}
+
+output "worker_service_name" {
+  description = "Worker ECS service name"
+  value       = module.ecs_service_worker.service_name
+}
+
+output "email_queue_arn" {
+  description = "Email outbox queue ARN"
+  value       = module.sqs_email_outbox.queue_arn
+}
+
+output "observability_dashboard" {
+  description = "CloudWatch dashboard name"
+  value       = module.observability.dashboard_name
+}
+
+output "alerts_topic_arn" {
+  description = "SNS topic ARN for alerts"
+  value       = module.observability.sns_topic_arn
+}
+
+output "github_oidc_role_arn" {
+  description = "GitHub Actions deploy role ARN"
+  value       = module.iam_roles.github_oidc_role_arn
+}
+
+output "secrets" {
+  description = "Secrets Manager ARNs"
+  value       = module.secrets.secret_arns
+}

--- a/infra/terraform/envs/dev/terraform.tfvars.example
+++ b/infra/terraform/envs/dev/terraform.tfvars.example
@@ -1,0 +1,31 @@
+region                  = "us-east-1"
+environment             = "dev"
+vpc_cidr                = "10.0.0.0/16"
+enable_nat_gateway      = true
+enable_fargate_spot     = true
+api_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-dev-api:main"
+web_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-dev-web:main"
+worker_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-dev-worker:main"
+api_domain              = "api.dev.jotiq.com"
+app_domain              = "app.dev.jotiq.com"
+assets_domain           = "assets.dev.jotiq.com"
+domain                  = "dev.jotiq.com"
+create_hosted_zone      = false
+hosted_zone_id          = "Z1234567890"
+alb_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234"
+cloudfront_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/efgh5678"
+cloudfront_waf_arn      = null
+ses_transactional_domain = "tx.dev.jotiq.com"
+ses_marketing_domain     = "mkt.dev.jotiq.com"
+ses_metrics_identity     = "tx.dev.jotiq.com"
+github_org              = "jotiq"
+github_repo             = "jotiq-app"
+api_environment = {
+  NODE_ENV = "production"
+}
+web_environment = {
+  NODE_ENV = "production"
+}
+worker_environment = {
+  NODE_ENV = "production"
+}

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -1,0 +1,313 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT gateways"
+  type        = bool
+  default     = true
+}
+
+variable "enable_fargate_spot" {
+  description = "Enable Fargate Spot"
+  type        = bool
+  default     = true
+}
+
+variable "default_tags" {
+  description = "Base tags"
+  type        = map(string)
+  default     = {
+    Owner      = "PlatformTeam"
+    CostCenter = "SaaS"
+  }
+}
+
+variable "log_retention_days" {
+  description = "Log retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "api_cpu_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "api_memory_alarm_threshold" {
+  type    = number
+  default = 80
+}
+
+variable "web_cpu_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "web_memory_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "worker_cpu_alarm_threshold" {
+  type    = number
+  default = 65
+}
+
+variable "worker_memory_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "alb_latency_threshold" {
+  description = "ALB latency threshold in seconds"
+  type        = number
+  default     = 0.75
+}
+
+variable "sqs_max_messages" {
+  description = "Max visible messages before alarm"
+  type        = number
+  default     = 200
+}
+
+variable "sqs_max_age_seconds" {
+  description = "Max age of oldest message"
+  type        = number
+  default     = 600
+}
+
+variable "sqs_retention_seconds" {
+  description = "SQS retention period"
+  type        = number
+  default     = 604800
+}
+
+variable "sqs_max_receive_count" {
+  description = "Max receive count before DLQ"
+  type        = number
+  default     = 5
+}
+
+variable "worker_visibility_timeout" {
+  description = "Worker visibility timeout"
+  type        = number
+  default     = 60
+}
+
+variable "worker_queue_target" {
+  description = "Target messages for worker autoscaling"
+  type        = number
+  default     = 10
+}
+
+variable "domain" {
+  description = "Primary domain"
+  type        = string
+}
+
+variable "create_hosted_zone" {
+  description = "Whether to create the hosted zone"
+  type        = bool
+  default     = false
+}
+
+variable "hosted_zone_id" {
+  description = "Existing hosted zone ID"
+  type        = string
+  default     = null
+}
+
+variable "api_domain" {
+  description = "API domain"
+  type        = string
+}
+
+variable "app_domain" {
+  description = "App domain"
+  type        = string
+}
+
+variable "assets_domain" {
+  description = "Assets domain"
+  type        = string
+}
+
+variable "alb_acm_certificate_arn" {
+  description = "ACM cert for ALB"
+  type        = string
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM cert for CloudFront"
+  type        = string
+}
+
+variable "cloudfront_waf_arn" {
+  description = "Optional WAF ARN"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "ses_transactional_domain" {
+  description = "Transactional SES domain"
+  type        = string
+}
+
+variable "ses_marketing_domain" {
+  description = "Marketing SES domain"
+  type        = string
+}
+
+variable "ses_metrics_identity" {
+  description = "SES identity to monitor"
+  type        = string
+}
+
+variable "ses_bounce_threshold" {
+  description = "Bounce rate threshold"
+  type        = number
+  default     = 5
+}
+
+variable "ses_complaint_threshold" {
+  description = "Complaint rate threshold"
+  type        = number
+  default     = 1
+}
+
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository"
+  type        = string
+}
+
+variable "api_image" {
+  description = "API image URI"
+  type        = string
+}
+
+variable "api_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "api_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "api_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "api_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "api_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "api_environment" {
+  description = "API environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "web_image" {
+  description = "Web image URI"
+  type        = string
+}
+
+variable "web_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "web_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "web_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "web_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "web_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "web_environment" {
+  description = "Web environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_image" {
+  description = "Worker image URI"
+  type        = string
+}
+
+variable "worker_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "worker_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "worker_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "worker_min_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "worker_max_capacity" {
+  type    = number
+  default = 4
+}
+
+variable "worker_environment" {
+  description = "Worker environment variables"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -1,0 +1,515 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  environment = var.environment
+  azs         = slice(data.aws_availability_zones.available.names, 0, 3)
+  tags = merge(var.default_tags, {
+    Project    = "JOTIQ"
+    Env        = local.environment
+  })
+  observability_services = [
+    {
+      name              = "api"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.api_cpu_alarm_threshold
+      memory_threshold  = var.api_memory_alarm_threshold
+    },
+    {
+      name              = "web"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.web_cpu_alarm_threshold
+      memory_threshold  = var.web_memory_alarm_threshold
+    },
+    {
+      name              = "worker"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.worker_cpu_alarm_threshold
+      memory_threshold  = var.worker_memory_alarm_threshold
+    }
+  ]
+}
+
+resource "aws_kms_key" "general" {
+  description         = "General purpose key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "general" {
+  name          = "alias/jotiq-${local.environment}-general"
+  target_key_id = aws_kms_key.general.key_id
+}
+
+resource "aws_kms_key" "sns" {
+  description         = "SNS encryption key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "sns" {
+  name          = "alias/jotiq-${local.environment}-sns"
+  target_key_id = aws_kms_key.sns.key_id
+}
+
+module "vpc" {
+  source     = "../../modules/vpc"
+  name       = "jotiq-${local.environment}"
+  cidr_block = var.vpc_cidr
+  azs        = local.azs
+  enable_nat = var.enable_nat_gateway
+  tags       = local.tags
+}
+
+module "endpoints" {
+  source                  = "../../modules/endpoints"
+  name                    = "jotiq-${local.environment}"
+  vpc_id                  = module.vpc.vpc_id
+  region                  = var.region
+  private_route_table_ids = module.vpc.private_route_table_ids
+  subnet_ids              = module.vpc.private_subnet_ids
+  allowed_cidrs           = [var.vpc_cidr]
+  tags                    = local.tags
+}
+
+module "secrets" {
+  source      = "../../modules/secrets"
+  project     = "jotiq"
+  environment = local.environment
+  tags        = local.tags
+}
+
+module "s3_logs" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-logs"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = null
+  tags       = local.tags
+}
+
+module "s3_assets" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-assets"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "assets"
+  tags       = local.tags
+}
+
+module "s3_backups" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-backups"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "backups"
+  tags       = local.tags
+}
+
+module "cloudfront" {
+  source                 = "../../modules/cloudfront_waf"
+  domain_name            = var.assets_domain
+  aliases                = [var.assets_domain]
+  s3_bucket_domain_name  = "${module.s3_assets.bucket_id}.s3.amazonaws.com"
+  acm_certificate_arn    = var.cloudfront_acm_certificate_arn
+  log_bucket_domain_name = "${module.s3_logs.bucket_id}.s3.amazonaws.com"
+  log_prefix             = "cloudfront"
+  web_acl_arn            = var.cloudfront_waf_arn
+  price_class            = var.cloudfront_price_class
+  tags                   = local.tags
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = module.s3_assets.bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontAccess"
+        Effect    = "Allow"
+        Principal = {
+          CanonicalUser = module.cloudfront.origin_access_identity_canonical_user_id
+        }
+        Action   = "s3:GetObject"
+        Resource = "${module.s3_assets.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic" "ses_feedback" {
+  name              = "jotiq-${local.environment}-ses-feedback"
+  kms_master_key_id = aws_kms_key.sns.arn
+  tags              = local.tags
+}
+
+module "ses_tx" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_transactional_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "ses_mkt" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_marketing_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "sqs_email_outbox" {
+  source                = "../../modules/sqs_queue"
+  name                  = "jotiq-${local.environment}-email-outbox"
+  kms_key_arn           = aws_kms_key.general.arn
+  visibility_timeout    = var.worker_visibility_timeout
+  retention_seconds     = var.sqs_retention_seconds
+  max_receive_count     = var.sqs_max_receive_count
+  tags                  = local.tags
+}
+
+module "ecr_api" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-api"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_web" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-web"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_worker" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-worker"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecs_cluster" {
+  source                  = "../../modules/ecs_cluster"
+  name                    = "jotiq-${local.environment}"
+  enable_container_insights = true
+  enable_fargate_spot     = var.enable_fargate_spot
+  tags                    = local.tags
+}
+
+module "alb" {
+  source                = "../../modules/alb"
+  name                  = "jotiq-${local.environment}-alb"
+  vpc_id                = module.vpc.vpc_id
+  subnet_ids            = module.vpc.public_subnet_ids
+  acm_certificate_arn   = var.alb_acm_certificate_arn
+  access_logs_bucket    = module.s3_logs.bucket_id
+  access_logs_prefix    = "alb"
+  tags                  = local.tags
+}
+
+locals {
+  alb_arn_suffix = element(split("loadbalancer/", module.alb.alb_arn), 1)
+  ses_records_map = merge(
+    {
+      tx_verification = {
+        name    = "_amazonses.${var.ses_transactional_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_tx.verification_token]
+      }
+    },
+    {
+      mkt_verification = {
+        name    = "_amazonses.${var.ses_marketing_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_mkt.verification_token]
+      }
+    },
+    {
+      tx_spf = {
+        name    = var.ses_transactional_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    {
+      mkt_spf = {
+        name    = var.ses_marketing_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    { for idx, token in module.ses_tx.dkim_tokens : "tx_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_transactional_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    },
+    { for idx, token in module.ses_mkt.dkim_tokens : "mkt_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_marketing_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    }
+  )
+}
+
+module "observability" {
+  source                = "../../modules/observability"
+  project               = "jotiq"
+  environment           = local.environment
+  services              = local.observability_services
+  log_kms_key_arn       = aws_kms_key.general.arn
+  sns_kms_key_arn       = aws_kms_key.sns.arn
+  alb_arn_suffix        = local.alb_arn_suffix
+  alb_latency_threshold = var.alb_latency_threshold
+  ecs_cluster_name      = module.ecs_cluster.cluster_name
+  sqs_queue_name        = module.sqs_email_outbox.queue_name
+  sqs_max_messages      = var.sqs_max_messages
+  sqs_max_age_seconds   = var.sqs_max_age_seconds
+  ses_identity          = var.ses_metrics_identity
+  ses_bounce_threshold    = var.ses_bounce_threshold
+  ses_complaint_threshold = var.ses_complaint_threshold
+  tags                  = local.tags
+}
+
+module "iam_roles" {
+  source         = "../../modules/iam_roles"
+  environment    = local.environment
+  log_group_arns = values(module.observability.log_group_arns)
+  secret_arns    = values(module.secrets.secret_arns)
+  s3_bucket_arns = [module.s3_assets.bucket_arn]
+  sqs_queue_arns = [module.sqs_email_outbox.queue_arn]
+  github_org     = var.github_org
+  github_repo    = var.github_repo
+  tags           = local.tags
+}
+
+resource "aws_security_group" "ecs_service" {
+  name        = "jotiq-${local.environment}-ecs-sg"
+  description = "Allow traffic from ALB"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description      = "App from ALB"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    security_groups  = [module.alb.security_group_id]
+  }
+
+  ingress {
+    description = "HTTPS egress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+locals {
+  api_log_group_name = module.observability.log_group_names["api"]
+  web_log_group_name = module.observability.log_group_names["web"]
+  worker_log_group_name = module.observability.log_group_names["worker"]
+  api_log_group_arn = module.observability.log_group_arns["api"]
+  web_log_group_arn = module.observability.log_group_arns["web"]
+  worker_log_group_arn = module.observability.log_group_arns["worker"]
+}
+
+module "ecs_service_api" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-api"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.api_image
+  cpu                = var.api_cpu
+  memory             = var.api_memory
+  desired_count      = var.api_desired_count
+  min_capacity       = var.api_min_capacity
+  max_capacity       = var.api_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 100
+  path_patterns      = ["/api/*"]
+  host_headers       = [var.api_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.api_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "JWT_SECRET", value_from = module.secrets.secret_arns["JWT_SECRET"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.api_log_group_name
+  log_group_arn      = local.api_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_5xx_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_web" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-web"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.web_image
+  cpu                = var.web_cpu
+  memory             = var.web_memory
+  desired_count      = var.web_desired_count
+  min_capacity       = var.web_min_capacity
+  max_capacity       = var.web_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 110
+  path_patterns      = ["/*"]
+  host_headers       = [var.app_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.web_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.web_log_group_name
+  log_group_arn      = local.web_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_latency_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_worker" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-worker"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.worker_image
+  cpu                = var.worker_cpu
+  memory             = var.worker_memory
+  desired_count      = var.worker_desired_count
+  min_capacity       = var.worker_min_capacity
+  max_capacity       = var.worker_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = ""
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.worker_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "SES_SMTP_USER", value_from = module.secrets.secret_arns["SES_SMTP_USER"] },
+    { name = "SES_SMTP_PASS", value_from = module.secrets.secret_arns["SES_SMTP_PASS"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.worker_log_group_name
+  log_group_arn      = local.worker_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = false
+  sqs_queue_metric = {
+    metric_name  = "ApproximateNumberOfMessagesVisible"
+    namespace    = "AWS/SQS"
+    statistic    = "Average"
+    unit         = "Count"
+    dimensions   = [{ name = "QueueName", value = module.sqs_email_outbox.queue_name }]
+    target_value = var.worker_queue_target
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "route53" {
+  source                    = "../../modules/route53"
+  create_zone               = var.create_hosted_zone
+  zone_name                 = var.domain
+  hosted_zone_id            = var.hosted_zone_id
+  api_record                = var.api_domain
+  app_record                = var.app_domain
+  assets_record             = var.assets_domain
+  alb_dns_name              = module.alb.alb_dns_name
+  alb_zone_id               = module.alb.alb_zone_id
+  cloudfront_domain_name    = module.cloudfront.distribution_domain_name
+  ses_records               = local.ses_records_map
+  tags = local.tags
+}
+
+resource "aws_ses_domain_identity_verification" "tx" {
+  domain     = var.ses_transactional_domain
+  depends_on = [module.route53]
+}
+
+resource "aws_ses_domain_identity_verification" "mkt" {
+  domain     = var.ses_marketing_domain
+  depends_on = [module.route53]
+}
+

--- a/infra/terraform/envs/prod/outputs.tf
+++ b/infra/terraform/envs/prod/outputs.tf
@@ -1,0 +1,49 @@
+output "alb_dns_name" {
+  description = "Application Load Balancer DNS name"
+  value       = module.alb.alb_dns_name
+}
+
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain"
+  value       = module.cloudfront.distribution_domain_name
+}
+
+output "api_service_name" {
+  description = "API ECS service name"
+  value       = module.ecs_service_api.service_name
+}
+
+output "web_service_name" {
+  description = "Web ECS service name"
+  value       = module.ecs_service_web.service_name
+}
+
+output "worker_service_name" {
+  description = "Worker ECS service name"
+  value       = module.ecs_service_worker.service_name
+}
+
+output "email_queue_arn" {
+  description = "Email outbox queue ARN"
+  value       = module.sqs_email_outbox.queue_arn
+}
+
+output "observability_dashboard" {
+  description = "CloudWatch dashboard name"
+  value       = module.observability.dashboard_name
+}
+
+output "alerts_topic_arn" {
+  description = "SNS topic ARN for alerts"
+  value       = module.observability.sns_topic_arn
+}
+
+output "github_oidc_role_arn" {
+  description = "GitHub Actions deploy role ARN"
+  value       = module.iam_roles.github_oidc_role_arn
+}
+
+output "secrets" {
+  description = "Secrets Manager ARNs"
+  value       = module.secrets.secret_arns
+}

--- a/infra/terraform/envs/prod/terraform.tfvars.example
+++ b/infra/terraform/envs/prod/terraform.tfvars.example
@@ -1,0 +1,31 @@
+region                  = "us-east-1"
+environment             = "prod"
+vpc_cidr                = "10.0.0.0/16"
+enable_nat_gateway      = true
+enable_fargate_spot     = true
+api_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-prod-api:main"
+web_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-prod-web:main"
+worker_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-prod-worker:main"
+api_domain              = "api.jotiq.com"
+app_domain              = "app.jotiq.com"
+assets_domain           = "assets.jotiq.com"
+domain                  = "jotiq.com"
+create_hosted_zone      = false
+hosted_zone_id          = "Z1234567890"
+alb_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234"
+cloudfront_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/efgh5678"
+cloudfront_waf_arn      = null
+ses_transactional_domain = "tx.jotiq.com"
+ses_marketing_domain     = "mkt.jotiq.com"
+ses_metrics_identity     = "tx.jotiq.com"
+github_org              = "jotiq"
+github_repo             = "jotiq-app"
+api_environment = {
+  NODE_ENV = "production"
+}
+web_environment = {
+  NODE_ENV = "production"
+}
+worker_environment = {
+  NODE_ENV = "production"
+}

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -1,0 +1,313 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT gateways"
+  type        = bool
+  default     = true
+}
+
+variable "enable_fargate_spot" {
+  description = "Enable Fargate Spot"
+  type        = bool
+  default     = true
+}
+
+variable "default_tags" {
+  description = "Base tags"
+  type        = map(string)
+  default     = {
+    Owner      = "PlatformTeam"
+    CostCenter = "SaaS"
+  }
+}
+
+variable "log_retention_days" {
+  description = "Log retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "api_cpu_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "api_memory_alarm_threshold" {
+  type    = number
+  default = 80
+}
+
+variable "web_cpu_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "web_memory_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "worker_cpu_alarm_threshold" {
+  type    = number
+  default = 65
+}
+
+variable "worker_memory_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "alb_latency_threshold" {
+  description = "ALB latency threshold in seconds"
+  type        = number
+  default     = 0.75
+}
+
+variable "sqs_max_messages" {
+  description = "Max visible messages before alarm"
+  type        = number
+  default     = 200
+}
+
+variable "sqs_max_age_seconds" {
+  description = "Max age of oldest message"
+  type        = number
+  default     = 600
+}
+
+variable "sqs_retention_seconds" {
+  description = "SQS retention period"
+  type        = number
+  default     = 604800
+}
+
+variable "sqs_max_receive_count" {
+  description = "Max receive count before DLQ"
+  type        = number
+  default     = 5
+}
+
+variable "worker_visibility_timeout" {
+  description = "Worker visibility timeout"
+  type        = number
+  default     = 60
+}
+
+variable "worker_queue_target" {
+  description = "Target messages for worker autoscaling"
+  type        = number
+  default     = 10
+}
+
+variable "domain" {
+  description = "Primary domain"
+  type        = string
+}
+
+variable "create_hosted_zone" {
+  description = "Whether to create the hosted zone"
+  type        = bool
+  default     = false
+}
+
+variable "hosted_zone_id" {
+  description = "Existing hosted zone ID"
+  type        = string
+  default     = null
+}
+
+variable "api_domain" {
+  description = "API domain"
+  type        = string
+}
+
+variable "app_domain" {
+  description = "App domain"
+  type        = string
+}
+
+variable "assets_domain" {
+  description = "Assets domain"
+  type        = string
+}
+
+variable "alb_acm_certificate_arn" {
+  description = "ACM cert for ALB"
+  type        = string
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM cert for CloudFront"
+  type        = string
+}
+
+variable "cloudfront_waf_arn" {
+  description = "Optional WAF ARN"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "ses_transactional_domain" {
+  description = "Transactional SES domain"
+  type        = string
+}
+
+variable "ses_marketing_domain" {
+  description = "Marketing SES domain"
+  type        = string
+}
+
+variable "ses_metrics_identity" {
+  description = "SES identity to monitor"
+  type        = string
+}
+
+variable "ses_bounce_threshold" {
+  description = "Bounce rate threshold"
+  type        = number
+  default     = 5
+}
+
+variable "ses_complaint_threshold" {
+  description = "Complaint rate threshold"
+  type        = number
+  default     = 1
+}
+
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository"
+  type        = string
+}
+
+variable "api_image" {
+  description = "API image URI"
+  type        = string
+}
+
+variable "api_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "api_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "api_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "api_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "api_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "api_environment" {
+  description = "API environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "web_image" {
+  description = "Web image URI"
+  type        = string
+}
+
+variable "web_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "web_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "web_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "web_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "web_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "web_environment" {
+  description = "Web environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_image" {
+  description = "Worker image URI"
+  type        = string
+}
+
+variable "worker_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "worker_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "worker_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "worker_min_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "worker_max_capacity" {
+  type    = number
+  default = 4
+}
+
+variable "worker_environment" {
+  description = "Worker environment variables"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/envs/staging/main.tf
+++ b/infra/terraform/envs/staging/main.tf
@@ -1,0 +1,515 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  environment = var.environment
+  azs         = slice(data.aws_availability_zones.available.names, 0, 3)
+  tags = merge(var.default_tags, {
+    Project    = "JOTIQ"
+    Env        = local.environment
+  })
+  observability_services = [
+    {
+      name              = "api"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.api_cpu_alarm_threshold
+      memory_threshold  = var.api_memory_alarm_threshold
+    },
+    {
+      name              = "web"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.web_cpu_alarm_threshold
+      memory_threshold  = var.web_memory_alarm_threshold
+    },
+    {
+      name              = "worker"
+      retention_in_days = var.log_retention_days
+      cpu_threshold     = var.worker_cpu_alarm_threshold
+      memory_threshold  = var.worker_memory_alarm_threshold
+    }
+  ]
+}
+
+resource "aws_kms_key" "general" {
+  description         = "General purpose key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "general" {
+  name          = "alias/jotiq-${local.environment}-general"
+  target_key_id = aws_kms_key.general.key_id
+}
+
+resource "aws_kms_key" "sns" {
+  description         = "SNS encryption key for ${local.environment}"
+  enable_key_rotation = true
+  tags                = local.tags
+}
+
+resource "aws_kms_alias" "sns" {
+  name          = "alias/jotiq-${local.environment}-sns"
+  target_key_id = aws_kms_key.sns.key_id
+}
+
+module "vpc" {
+  source     = "../../modules/vpc"
+  name       = "jotiq-${local.environment}"
+  cidr_block = var.vpc_cidr
+  azs        = local.azs
+  enable_nat = var.enable_nat_gateway
+  tags       = local.tags
+}
+
+module "endpoints" {
+  source                  = "../../modules/endpoints"
+  name                    = "jotiq-${local.environment}"
+  vpc_id                  = module.vpc.vpc_id
+  region                  = var.region
+  private_route_table_ids = module.vpc.private_route_table_ids
+  subnet_ids              = module.vpc.private_subnet_ids
+  allowed_cidrs           = [var.vpc_cidr]
+  tags                    = local.tags
+}
+
+module "secrets" {
+  source      = "../../modules/secrets"
+  project     = "jotiq"
+  environment = local.environment
+  tags        = local.tags
+}
+
+module "s3_logs" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-logs"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = null
+  tags       = local.tags
+}
+
+module "s3_assets" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-assets"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "assets"
+  tags       = local.tags
+}
+
+module "s3_backups" {
+  source     = "../../modules/s3_bucket"
+  name       = "jotiq-${local.environment}-backups"
+  kms_key_arn = aws_kms_key.general.arn
+  enable_versioning = true
+  log_bucket = module.s3_logs.bucket_id
+  log_prefix = "backups"
+  tags       = local.tags
+}
+
+module "cloudfront" {
+  source                 = "../../modules/cloudfront_waf"
+  domain_name            = var.assets_domain
+  aliases                = [var.assets_domain]
+  s3_bucket_domain_name  = "${module.s3_assets.bucket_id}.s3.amazonaws.com"
+  acm_certificate_arn    = var.cloudfront_acm_certificate_arn
+  log_bucket_domain_name = "${module.s3_logs.bucket_id}.s3.amazonaws.com"
+  log_prefix             = "cloudfront"
+  web_acl_arn            = var.cloudfront_waf_arn
+  price_class            = var.cloudfront_price_class
+  tags                   = local.tags
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = module.s3_assets.bucket_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontAccess"
+        Effect    = "Allow"
+        Principal = {
+          CanonicalUser = module.cloudfront.origin_access_identity_canonical_user_id
+        }
+        Action   = "s3:GetObject"
+        Resource = "${module.s3_assets.bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic" "ses_feedback" {
+  name              = "jotiq-${local.environment}-ses-feedback"
+  kms_master_key_id = aws_kms_key.sns.arn
+  tags              = local.tags
+}
+
+module "ses_tx" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_transactional_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "ses_mkt" {
+  source         = "../../modules/ses_domain"
+  domain         = var.ses_marketing_domain
+  hosted_zone_id = var.hosted_zone_id
+  sns_topic_arn  = aws_sns_topic.ses_feedback.arn
+  create_route53_records = false
+  tags           = local.tags
+}
+
+module "sqs_email_outbox" {
+  source                = "../../modules/sqs_queue"
+  name                  = "jotiq-${local.environment}-email-outbox"
+  kms_key_arn           = aws_kms_key.general.arn
+  visibility_timeout    = var.worker_visibility_timeout
+  retention_seconds     = var.sqs_retention_seconds
+  max_receive_count     = var.sqs_max_receive_count
+  tags                  = local.tags
+}
+
+module "ecr_api" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-api"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_web" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-web"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecr_worker" {
+  source     = "../../modules/ecr_repo"
+  name       = "jotiq-${local.environment}-worker"
+  kms_key_arn = aws_kms_key.general.arn
+  tags       = local.tags
+}
+
+module "ecs_cluster" {
+  source                  = "../../modules/ecs_cluster"
+  name                    = "jotiq-${local.environment}"
+  enable_container_insights = true
+  enable_fargate_spot     = var.enable_fargate_spot
+  tags                    = local.tags
+}
+
+module "alb" {
+  source                = "../../modules/alb"
+  name                  = "jotiq-${local.environment}-alb"
+  vpc_id                = module.vpc.vpc_id
+  subnet_ids            = module.vpc.public_subnet_ids
+  acm_certificate_arn   = var.alb_acm_certificate_arn
+  access_logs_bucket    = module.s3_logs.bucket_id
+  access_logs_prefix    = "alb"
+  tags                  = local.tags
+}
+
+locals {
+  alb_arn_suffix = element(split("loadbalancer/", module.alb.alb_arn), 1)
+  ses_records_map = merge(
+    {
+      tx_verification = {
+        name    = "_amazonses.${var.ses_transactional_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_tx.verification_token]
+      }
+    },
+    {
+      mkt_verification = {
+        name    = "_amazonses.${var.ses_marketing_domain}"
+        type    = "TXT"
+        ttl     = 600
+        records = [module.ses_mkt.verification_token]
+      }
+    },
+    {
+      tx_spf = {
+        name    = var.ses_transactional_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    {
+      mkt_spf = {
+        name    = var.ses_marketing_domain
+        type    = "TXT"
+        ttl     = 600
+        records = ["v=spf1 include:amazonses.com -all"]
+      }
+    },
+    { for idx, token in module.ses_tx.dkim_tokens : "tx_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_transactional_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    },
+    { for idx, token in module.ses_mkt.dkim_tokens : "mkt_dkim_${idx}" => {
+        name    = "${token}._domainkey.${var.ses_marketing_domain}"
+        type    = "CNAME"
+        ttl     = 600
+        records = ["${token}.dkim.amazonses.com"]
+      }
+    }
+  )
+}
+
+module "observability" {
+  source                = "../../modules/observability"
+  project               = "jotiq"
+  environment           = local.environment
+  services              = local.observability_services
+  log_kms_key_arn       = aws_kms_key.general.arn
+  sns_kms_key_arn       = aws_kms_key.sns.arn
+  alb_arn_suffix        = local.alb_arn_suffix
+  alb_latency_threshold = var.alb_latency_threshold
+  ecs_cluster_name      = module.ecs_cluster.cluster_name
+  sqs_queue_name        = module.sqs_email_outbox.queue_name
+  sqs_max_messages      = var.sqs_max_messages
+  sqs_max_age_seconds   = var.sqs_max_age_seconds
+  ses_identity          = var.ses_metrics_identity
+  ses_bounce_threshold    = var.ses_bounce_threshold
+  ses_complaint_threshold = var.ses_complaint_threshold
+  tags                  = local.tags
+}
+
+module "iam_roles" {
+  source         = "../../modules/iam_roles"
+  environment    = local.environment
+  log_group_arns = values(module.observability.log_group_arns)
+  secret_arns    = values(module.secrets.secret_arns)
+  s3_bucket_arns = [module.s3_assets.bucket_arn]
+  sqs_queue_arns = [module.sqs_email_outbox.queue_arn]
+  github_org     = var.github_org
+  github_repo    = var.github_repo
+  tags           = local.tags
+}
+
+resource "aws_security_group" "ecs_service" {
+  name        = "jotiq-${local.environment}-ecs-sg"
+  description = "Allow traffic from ALB"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description      = "App from ALB"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    security_groups  = [module.alb.security_group_id]
+  }
+
+  ingress {
+    description = "HTTPS egress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+locals {
+  api_log_group_name = module.observability.log_group_names["api"]
+  web_log_group_name = module.observability.log_group_names["web"]
+  worker_log_group_name = module.observability.log_group_names["worker"]
+  api_log_group_arn = module.observability.log_group_arns["api"]
+  web_log_group_arn = module.observability.log_group_arns["web"]
+  worker_log_group_arn = module.observability.log_group_arns["worker"]
+}
+
+module "ecs_service_api" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-api"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.api_image
+  cpu                = var.api_cpu
+  memory             = var.api_memory
+  desired_count      = var.api_desired_count
+  min_capacity       = var.api_min_capacity
+  max_capacity       = var.api_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 100
+  path_patterns      = ["/api/*"]
+  host_headers       = [var.api_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.api_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "JWT_SECRET", value_from = module.secrets.secret_arns["JWT_SECRET"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.api_log_group_name
+  log_group_arn      = local.api_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_5xx_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_web" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-web"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.web_image
+  cpu                = var.web_cpu
+  memory             = var.web_memory
+  desired_count      = var.web_desired_count
+  min_capacity       = var.web_min_capacity
+  max_capacity       = var.web_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  listener_arn       = module.alb.https_listener_arn
+  listener_priority  = 110
+  path_patterns      = ["/*"]
+  host_headers       = [var.app_domain]
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.web_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.web_log_group_name
+  log_group_arn      = local.web_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = true
+  codedeploy_role_arn = module.iam_roles.codedeploy_role_arn
+  codedeploy_alarm_configuration = {
+    enabled     = true
+    alarm_names = [module.observability.alb_latency_alarm_name]
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "ecs_service_worker" {
+  source             = "../../modules/ecs_service"
+  name               = "jotiq-${local.environment}-worker"
+  cluster_arn        = module.ecs_cluster.cluster_id
+  cluster_name       = module.ecs_cluster.cluster_name
+  container_image    = var.worker_image
+  cpu                = var.worker_cpu
+  memory             = var.worker_memory
+  desired_count      = var.worker_desired_count
+  min_capacity       = var.worker_min_capacity
+  max_capacity       = var.worker_max_capacity
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.ecs_service.id]
+  assign_public_ip   = false
+  listener_arn       = ""
+  health_check_path  = "/health"
+  service_port       = 3000
+  environment        = var.worker_environment
+  secrets            = [
+    { name = "MONGODB_URI", value_from = module.secrets.secret_arns["MONGODB_URI"] },
+    { name = "SES_SMTP_USER", value_from = module.secrets.secret_arns["SES_SMTP_USER"] },
+    { name = "SES_SMTP_PASS", value_from = module.secrets.secret_arns["SES_SMTP_PASS"] }
+  ]
+  aws_region         = var.region
+  log_group_name     = local.worker_log_group_name
+  log_group_arn      = local.worker_log_group_arn
+  create_log_group   = false
+  execution_role_arn = module.iam_roles.execution_role_arn
+  task_role_arn      = module.iam_roles.task_role_arn
+  secret_arns        = values(module.secrets.secret_arns)
+  sqs_queue_arns     = [module.sqs_email_outbox.queue_arn]
+  s3_bucket_arns     = [module.s3_assets.bucket_arn]
+  vpc_id             = module.vpc.vpc_id
+  enable_codedeploy  = false
+  sqs_queue_metric = {
+    metric_name  = "ApproximateNumberOfMessagesVisible"
+    namespace    = "AWS/SQS"
+    statistic    = "Average"
+    unit         = "Count"
+    dimensions   = [{ name = "QueueName", value = module.sqs_email_outbox.queue_name }]
+    target_value = var.worker_queue_target
+  }
+  enable_execute_command = true
+  tags              = local.tags
+}
+
+module "route53" {
+  source                    = "../../modules/route53"
+  create_zone               = var.create_hosted_zone
+  zone_name                 = var.domain
+  hosted_zone_id            = var.hosted_zone_id
+  api_record                = var.api_domain
+  app_record                = var.app_domain
+  assets_record             = var.assets_domain
+  alb_dns_name              = module.alb.alb_dns_name
+  alb_zone_id               = module.alb.alb_zone_id
+  cloudfront_domain_name    = module.cloudfront.distribution_domain_name
+  ses_records               = local.ses_records_map
+  tags = local.tags
+}
+
+resource "aws_ses_domain_identity_verification" "tx" {
+  domain     = var.ses_transactional_domain
+  depends_on = [module.route53]
+}
+
+resource "aws_ses_domain_identity_verification" "mkt" {
+  domain     = var.ses_marketing_domain
+  depends_on = [module.route53]
+}
+

--- a/infra/terraform/envs/staging/outputs.tf
+++ b/infra/terraform/envs/staging/outputs.tf
@@ -1,0 +1,49 @@
+output "alb_dns_name" {
+  description = "Application Load Balancer DNS name"
+  value       = module.alb.alb_dns_name
+}
+
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain"
+  value       = module.cloudfront.distribution_domain_name
+}
+
+output "api_service_name" {
+  description = "API ECS service name"
+  value       = module.ecs_service_api.service_name
+}
+
+output "web_service_name" {
+  description = "Web ECS service name"
+  value       = module.ecs_service_web.service_name
+}
+
+output "worker_service_name" {
+  description = "Worker ECS service name"
+  value       = module.ecs_service_worker.service_name
+}
+
+output "email_queue_arn" {
+  description = "Email outbox queue ARN"
+  value       = module.sqs_email_outbox.queue_arn
+}
+
+output "observability_dashboard" {
+  description = "CloudWatch dashboard name"
+  value       = module.observability.dashboard_name
+}
+
+output "alerts_topic_arn" {
+  description = "SNS topic ARN for alerts"
+  value       = module.observability.sns_topic_arn
+}
+
+output "github_oidc_role_arn" {
+  description = "GitHub Actions deploy role ARN"
+  value       = module.iam_roles.github_oidc_role_arn
+}
+
+output "secrets" {
+  description = "Secrets Manager ARNs"
+  value       = module.secrets.secret_arns
+}

--- a/infra/terraform/envs/staging/terraform.tfvars.example
+++ b/infra/terraform/envs/staging/terraform.tfvars.example
@@ -1,0 +1,31 @@
+region                  = "us-east-1"
+environment             = "staging"
+vpc_cidr                = "10.0.0.0/16"
+enable_nat_gateway      = true
+enable_fargate_spot     = true
+api_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-staging-api:main"
+web_image               = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-staging-web:main"
+worker_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/jotiq-staging-worker:main"
+api_domain              = "api.staging.jotiq.com"
+app_domain              = "app.staging.jotiq.com"
+assets_domain           = "assets.staging.jotiq.com"
+domain                  = "staging.jotiq.com"
+create_hosted_zone      = false
+hosted_zone_id          = "Z1234567890"
+alb_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abcd1234"
+cloudfront_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/efgh5678"
+cloudfront_waf_arn      = null
+ses_transactional_domain = "tx.staging.jotiq.com"
+ses_marketing_domain     = "mkt.staging.jotiq.com"
+ses_metrics_identity     = "tx.staging.jotiq.com"
+github_org              = "jotiq"
+github_repo             = "jotiq-app"
+api_environment = {
+  NODE_ENV = "production"
+}
+web_environment = {
+  NODE_ENV = "production"
+}
+worker_environment = {
+  NODE_ENV = "production"
+}

--- a/infra/terraform/envs/staging/variables.tf
+++ b/infra/terraform/envs/staging/variables.tf
@@ -1,0 +1,313 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "staging"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT gateways"
+  type        = bool
+  default     = true
+}
+
+variable "enable_fargate_spot" {
+  description = "Enable Fargate Spot"
+  type        = bool
+  default     = true
+}
+
+variable "default_tags" {
+  description = "Base tags"
+  type        = map(string)
+  default     = {
+    Owner      = "PlatformTeam"
+    CostCenter = "SaaS"
+  }
+}
+
+variable "log_retention_days" {
+  description = "Log retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "api_cpu_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "api_memory_alarm_threshold" {
+  type    = number
+  default = 80
+}
+
+variable "web_cpu_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "web_memory_alarm_threshold" {
+  type    = number
+  default = 75
+}
+
+variable "worker_cpu_alarm_threshold" {
+  type    = number
+  default = 65
+}
+
+variable "worker_memory_alarm_threshold" {
+  type    = number
+  default = 70
+}
+
+variable "alb_latency_threshold" {
+  description = "ALB latency threshold in seconds"
+  type        = number
+  default     = 0.75
+}
+
+variable "sqs_max_messages" {
+  description = "Max visible messages before alarm"
+  type        = number
+  default     = 200
+}
+
+variable "sqs_max_age_seconds" {
+  description = "Max age of oldest message"
+  type        = number
+  default     = 600
+}
+
+variable "sqs_retention_seconds" {
+  description = "SQS retention period"
+  type        = number
+  default     = 604800
+}
+
+variable "sqs_max_receive_count" {
+  description = "Max receive count before DLQ"
+  type        = number
+  default     = 5
+}
+
+variable "worker_visibility_timeout" {
+  description = "Worker visibility timeout"
+  type        = number
+  default     = 60
+}
+
+variable "worker_queue_target" {
+  description = "Target messages for worker autoscaling"
+  type        = number
+  default     = 10
+}
+
+variable "domain" {
+  description = "Primary domain"
+  type        = string
+}
+
+variable "create_hosted_zone" {
+  description = "Whether to create the hosted zone"
+  type        = bool
+  default     = false
+}
+
+variable "hosted_zone_id" {
+  description = "Existing hosted zone ID"
+  type        = string
+  default     = null
+}
+
+variable "api_domain" {
+  description = "API domain"
+  type        = string
+}
+
+variable "app_domain" {
+  description = "App domain"
+  type        = string
+}
+
+variable "assets_domain" {
+  description = "Assets domain"
+  type        = string
+}
+
+variable "alb_acm_certificate_arn" {
+  description = "ACM cert for ALB"
+  type        = string
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM cert for CloudFront"
+  type        = string
+}
+
+variable "cloudfront_waf_arn" {
+  description = "Optional WAF ARN"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "ses_transactional_domain" {
+  description = "Transactional SES domain"
+  type        = string
+}
+
+variable "ses_marketing_domain" {
+  description = "Marketing SES domain"
+  type        = string
+}
+
+variable "ses_metrics_identity" {
+  description = "SES identity to monitor"
+  type        = string
+}
+
+variable "ses_bounce_threshold" {
+  description = "Bounce rate threshold"
+  type        = number
+  default     = 5
+}
+
+variable "ses_complaint_threshold" {
+  description = "Complaint rate threshold"
+  type        = number
+  default     = 1
+}
+
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository"
+  type        = string
+}
+
+variable "api_image" {
+  description = "API image URI"
+  type        = string
+}
+
+variable "api_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "api_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "api_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "api_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "api_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "api_environment" {
+  description = "API environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "web_image" {
+  description = "Web image URI"
+  type        = string
+}
+
+variable "web_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "web_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "web_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "web_min_capacity" {
+  type    = number
+  default = 2
+}
+
+variable "web_max_capacity" {
+  type    = number
+  default = 6
+}
+
+variable "web_environment" {
+  description = "Web environment variables"
+  type        = map(string)
+  default     = {}
+}
+
+variable "worker_image" {
+  description = "Worker image URI"
+  type        = string
+}
+
+variable "worker_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "worker_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "worker_desired_count" {
+  type    = number
+  default = 2
+}
+
+variable "worker_min_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "worker_max_capacity" {
+  type    = number
+  default = 4
+}
+
+variable "worker_environment" {
+  description = "Worker environment variables"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/global/backend/main.tf
+++ b/infra/terraform/global/backend/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.region
+}
+
+locals {
+  backend_config = {
+    bucket         = var.state_bucket
+    key            = "${var.state_key_prefix}/terraform.tfstate"
+    dynamodb_table = var.lock_table
+    region         = var.region
+  }
+}
+
+resource "aws_kms_key" "backend" {
+  description         = "Terraform backend encryption key"
+  enable_key_rotation = true
+  tags                = merge(var.tags, { Name = "jotiq-backend-kms" })
+}
+
+resource "aws_s3_bucket" "state" {
+  bucket = var.state_bucket
+  tags   = merge(var.tags, { Name = "jotiq-terraform-state" })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.backend.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket                  = aws_s3_bucket.state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    id     = "retention"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "lock" {
+  name         = var.lock_table
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = merge(var.tags, { Name = "jotiq-terraform-locks" })
+}

--- a/infra/terraform/global/backend/outputs.tf
+++ b/infra/terraform/global/backend/outputs.tf
@@ -1,0 +1,14 @@
+output "state_bucket_name" {
+  description = "S3 bucket storing Terraform state"
+  value       = aws_s3_bucket.state.id
+}
+
+output "lock_table_name" {
+  description = "DynamoDB lock table"
+  value       = aws_dynamodb_table.lock.name
+}
+
+output "kms_key_arn" {
+  description = "KMS key ARN for backend encryption"
+  value       = aws_kms_key.backend.arn
+}

--- a/infra/terraform/global/backend/variables.tf
+++ b/infra/terraform/global/backend/variables.tf
@@ -1,0 +1,30 @@
+variable "state_bucket" {
+  description = "Name of the S3 bucket that stores Terraform state"
+  type        = string
+}
+
+variable "state_key_prefix" {
+  description = "Prefix for storing state files"
+  type        = string
+  default     = "global/backend"
+}
+
+variable "lock_table" {
+  description = "DynamoDB table name for state locking"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for backend resources"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags applied to backend resources"
+  type        = map(string)
+  default = {
+    Project    = "JOTIQ"
+    Owner      = "PlatformTeam"
+    CostCenter = "Shared"
+  }
+}

--- a/infra/terraform/global/org_security/main.tf
+++ b/infra/terraform/global/org_security/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name              = "jotiq-monthly-budget"
+  budget_type       = "COST"
+  limit_amount      = var.monthly_budget_amount
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = var.budget_start
+
+  cost_filters = {
+    TagKeyValue = "Project$JOTIQ"
+  }
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold           = 80
+    threshold_type      = "PERCENTAGE"
+    notification_type   = "FORECASTED"
+
+    subscriber {
+      subscription_type = "EMAIL"
+      address           = var.budget_notification_email
+    }
+  }
+}
+
+resource "aws_guardduty_detector" "this" {
+  enable = true
+}
+
+resource "aws_config_configuration_recorder" "this" {
+  name     = "jotiq-config-recorder"
+  role_arn = var.config_role_arn
+
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = true
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "this" {
+  name       = aws_config_configuration_recorder.this.name
+  is_enabled = true
+}
+
+resource "aws_config_delivery_channel" "this" {
+  name           = "jotiq-config-channel"
+  s3_bucket_name = var.config_bucket
+  sns_topic_arn  = var.config_sns_topic
+
+  depends_on = [aws_config_configuration_recorder.this]
+}
+
+resource "aws_cloudtrail" "this" {
+  name                          = "jotiq-org-trail"
+  s3_bucket_name                = var.cloudtrail_bucket
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  enable_log_file_validation    = true
+  kms_key_id                    = var.cloudtrail_kms_key
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+  }
+}
+
+resource "aws_securityhub_account" "this" {}
+
+resource "aws_securityhub_standards_subscription" "cis" {
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  depends_on    = [aws_securityhub_account.this]
+}
+

--- a/infra/terraform/global/org_security/outputs.tf
+++ b/infra/terraform/global/org_security/outputs.tf
@@ -1,0 +1,14 @@
+output "guardduty_detector_id" {
+  description = "GuardDuty detector ID"
+  value       = aws_guardduty_detector.this.id
+}
+
+output "budget_id" {
+  description = "Monthly budget name"
+  value       = aws_budgets_budget.monthly.name
+}
+
+output "securityhub_subscriptions" {
+  description = "SecurityHub standard subscriptions"
+  value       = [aws_securityhub_standards_subscription.cis.standards_arn]
+}

--- a/infra/terraform/global/org_security/variables.tf
+++ b/infra/terraform/global/org_security/variables.tf
@@ -1,0 +1,44 @@
+variable "region" {
+  description = "AWS region to deploy org-wide security controls"
+  type        = string
+}
+
+variable "monthly_budget_amount" {
+  description = "Monthly budget limit for the account"
+  type        = string
+}
+
+variable "budget_start" {
+  description = "Start date for the budget (YYYY-MM-DD)"
+  type        = string
+}
+
+variable "budget_notification_email" {
+  description = "Email address to receive budget alerts"
+  type        = string
+}
+
+variable "config_role_arn" {
+  description = "IAM role ARN assumed by AWS Config"
+  type        = string
+}
+
+variable "config_bucket" {
+  description = "S3 bucket that stores AWS Config snapshots"
+  type        = string
+}
+
+variable "config_sns_topic" {
+  description = "SNS topic ARN for Config notifications"
+  type        = string
+}
+
+variable "cloudtrail_bucket" {
+  description = "S3 bucket for CloudTrail logs"
+  type        = string
+}
+
+variable "cloudtrail_kms_key" {
+  description = "KMS key ARN for encrypting CloudTrail logs"
+  type        = string
+}

--- a/infra/terraform/modules/alb/main.tf
+++ b/infra/terraform/modules/alb/main.tf
@@ -1,0 +1,81 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.name}-alb-sg"
+  description = "Allow HTTP/HTTPS"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-alb-sg" })
+}
+
+resource "aws_lb" "this" {
+  name               = var.name
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.subnet_ids
+  idle_timeout       = 60
+  internal           = false
+
+  access_logs {
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
+    enabled = true
+  }
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      status_code = "HTTP_301"
+      port        = "443"
+      protocol    = "HTTPS"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      status_code  = "404"
+      content_type = "text/plain"
+      message_body = "Not Found"
+    }
+  }
+}

--- a/infra/terraform/modules/alb/outputs.tf
+++ b/infra/terraform/modules/alb/outputs.tf
@@ -1,0 +1,29 @@
+output "alb_arn" {
+  description = "ARN of the ALB"
+  value       = aws_lb.this.arn
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = aws_lb.this.dns_name
+}
+
+output "security_group_id" {
+  description = "Security group ID for the ALB"
+  value       = aws_security_group.alb.id
+}
+
+output "http_listener_arn" {
+  description = "HTTP listener ARN"
+  value       = aws_lb_listener.http.arn
+}
+
+output "https_listener_arn" {
+  description = "HTTPS listener ARN"
+  value       = aws_lb_listener.https.arn
+}
+
+output "alb_zone_id" {
+  description = "Hosted zone ID for ALB"
+  value       = aws_lb.this.zone_id
+}

--- a/infra/terraform/modules/alb/variables.tf
+++ b/infra/terraform/modules/alb/variables.tf
@@ -1,0 +1,42 @@
+variable "name" {
+  description = "ALB name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Public subnet IDs"
+  type        = list(string)
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN"
+  type        = string
+}
+
+variable "access_logs_bucket" {
+  description = "S3 bucket for access logs"
+  type        = string
+}
+
+variable "access_logs_prefix" {
+  description = "Prefix for access logs"
+  type        = string
+  default     = "alb"
+}
+
+variable "ingress_cidrs" {
+  description = "Allowed ingress CIDR blocks"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/cloudfront_waf/main.tf
+++ b/infra/terraform/modules/cloudfront_waf/main.tf
@@ -1,0 +1,59 @@
+resource "aws_cloudfront_origin_access_identity" "this" {
+  comment = "OAI for ${var.domain_name}"
+}
+
+locals {
+  cache_policy_id = var.cache_policy_id != null ? var.cache_policy_id : "658327ea-f89d-4fab-a63d-7e88639e58f6" # CachingOptimized
+  origin_id       = "s3-${var.s3_bucket_domain_name}"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = var.comment
+  default_root_object = var.default_root_object
+  price_class         = var.price_class
+  web_acl_id          = var.web_acl_arn
+
+  aliases = var.aliases
+
+  origin {
+    domain_name = var.s3_bucket_domain_name
+    origin_id   = local.origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.origin_id
+
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = local.cache_policy_id
+
+    compress = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = var.acm_certificate_arn
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.2_2021"
+  }
+
+  logging_config {
+    bucket = var.log_bucket_domain_name
+    prefix = var.log_prefix
+    include_cookies = false
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/cloudfront_waf/outputs.tf
+++ b/infra/terraform/modules/cloudfront_waf/outputs.tf
@@ -1,0 +1,24 @@
+output "distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_domain_name" {
+  description = "Distribution domain name"
+  value       = aws_cloudfront_distribution.this.domain_name
+}
+
+output "origin_access_identity_path" {
+  description = "Origin access identity path"
+  value       = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+}
+
+output "origin_access_identity_arn" {
+  description = "Origin access identity IAM ARN"
+  value       = aws_cloudfront_origin_access_identity.this.iam_arn
+}
+
+output "origin_access_identity_canonical_user_id" {
+  description = "Origin access identity canonical user ID"
+  value       = aws_cloudfront_origin_access_identity.this.s3_canonical_user_id
+}

--- a/infra/terraform/modules/cloudfront_waf/variables.tf
+++ b/infra/terraform/modules/cloudfront_waf/variables.tf
@@ -1,0 +1,67 @@
+variable "domain_name" {
+  description = "Primary domain name"
+  type        = string
+}
+
+variable "aliases" {
+  description = "Alternate domain names"
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_bucket_domain_name" {
+  description = "S3 bucket domain name"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN in us-east-1"
+  type        = string
+}
+
+variable "log_bucket_domain_name" {
+  description = "S3 bucket domain for logs"
+  type        = string
+}
+
+variable "log_prefix" {
+  description = "Log prefix"
+  type        = string
+  default     = "cloudfront"
+}
+
+variable "cache_policy_id" {
+  description = "Cache policy ID"
+  type        = string
+  default     = null
+}
+
+variable "web_acl_arn" {
+  description = "Optional WAF ARN"
+  type        = string
+  default     = null
+}
+
+variable "price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "default_root_object" {
+  description = "Default root object"
+  type        = string
+  default     = "index.html"
+}
+
+variable "comment" {
+  description = "Distribution comment"
+  type        = string
+  default     = "JOTIQ assets distribution"
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ecr_repo/main.tf
+++ b/infra/terraform/modules/ecr_repo/main.tf
@@ -1,0 +1,36 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key_arn
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Retain last 20 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 20
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr_repo/outputs.tf
+++ b/infra/terraform/modules/ecr_repo/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "ECR repository ARN"
+  value       = aws_ecr_repository.this.arn
+}

--- a/infra/terraform/modules/ecr_repo/variables.tf
+++ b/infra/terraform/modules/ecr_repo/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "Name of the ECR repository"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN for encryption"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ecs_cluster/main.tf
+++ b/infra/terraform/modules/ecs_cluster/main.tf
@@ -1,0 +1,29 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+
+  setting {
+    name  = "containerInsights"
+    value = var.enable_container_insights ? "enabled" : "disabled"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name = aws_ecs_cluster.this.name
+  capacity_providers = var.enable_fargate_spot ? ["FARGATE", "FARGATE_SPOT"] : ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 1
+  }
+
+  dynamic "default_capacity_provider_strategy" {
+    for_each = var.enable_fargate_spot ? ["spot"] : []
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 1
+    }
+  }
+}

--- a/infra/terraform/modules/ecs_cluster/outputs.tf
+++ b/infra/terraform/modules/ecs_cluster/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_id" {
+  description = "ID of the ECS cluster"
+  value       = aws_ecs_cluster.this.id
+}
+
+output "cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.this.name
+}

--- a/infra/terraform/modules/ecs_cluster/variables.tf
+++ b/infra/terraform/modules/ecs_cluster/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  description = "Name of the ECS cluster"
+  type        = string
+}
+
+variable "enable_container_insights" {
+  description = "Enable Container Insights"
+  type        = bool
+  default     = true
+}
+
+variable "enable_fargate_spot" {
+  description = "Enable Fargate Spot capacity provider"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ecs_service/main.tf
+++ b/infra/terraform/modules/ecs_service/main.tf
@@ -1,0 +1,379 @@
+locals {
+  container_name     = "${var.name}-container"
+  log_stream_prefix  = replace(var.name, " ", "-")
+  enable_alb         = var.listener_arn != null && var.listener_arn != ""
+  enable_cd          = var.enable_codedeploy && local.enable_alb
+}
+
+resource "aws_lb_target_group" "blue" {
+  count    = local.enable_alb ? 1 : 0
+  name     = substr("${var.name}-blue", 0, 32)
+  port     = var.service_port
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-tg-blue" })
+}
+
+resource "aws_lb_target_group" "green" {
+  count = local.enable_cd ? 1 : 0
+
+  name     = substr("${var.name}-green", 0, 32)
+  port     = var.service_port
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-tg-green" })
+}
+
+resource "aws_lb_listener_rule" "this" {
+  count        = local.enable_alb ? 1 : 0
+  listener_arn = var.listener_arn
+  priority     = var.listener_priority
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.blue[0].arn
+  }
+
+  condition {
+    path_pattern {
+      values = var.path_patterns
+    }
+  }
+
+  condition {
+    host_header {
+      values = var.host_headers
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [action]
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  count = var.execution_role_arn == null ? 1 : 0
+
+  name = "${var.name}-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  count      = var.execution_role_arn == null ? 1 : 0
+  role       = aws_iam_role.task_execution[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  count = var.task_role_arn == null ? 1 : 0
+
+  name = "${var.name}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "task_inline" {
+  count = var.task_role_arn == null ? 1 : 0
+
+  name = "${var.name}-task-inline"
+  role = aws_iam_role.task[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(var.task_additional_policy_statements, [
+      {
+        Sid    = "AllowLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = [local.log_group_arn]
+      },
+      {
+        Sid    = "AllowSecretsManager"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = var.secret_arns
+      },
+      {
+        Sid    = "AllowSQS"
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility"
+        ]
+        Resource = var.sqs_queue_arns
+      },
+      {
+        Sid    = "AllowS3List"
+        Effect = "Allow"
+        Action = ["s3:ListBucket"]
+        Resource = var.s3_bucket_arns
+      },
+      {
+        Sid    = "AllowS3Objects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = [for bucket in var.s3_bucket_arns : "${bucket}/*"]
+      }
+    ])
+  })
+}
+
+resource "aws_cloudwatch_log_group" "default" {
+  count = var.create_log_group ? 1 : 0
+
+  name              = var.log_group_name
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.log_kms_key_arn
+
+  tags = var.tags
+}
+
+locals {
+  execution_role_arn = coalesce(var.execution_role_arn, try(aws_iam_role.task_execution[0].arn, null))
+  task_role_arn      = coalesce(var.task_role_arn, try(aws_iam_role.task[0].arn, null))
+  target_group_arn   = local.enable_alb ? aws_lb_target_group.blue[0].arn : null
+  log_group_arn      = coalesce(var.log_group_arn, try(aws_cloudwatch_log_group.default[0].arn, null))
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  cpu                      = var.cpu
+  memory                   = var.memory
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  execution_role_arn       = local.execution_role_arn
+  task_role_arn            = local.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = local.container_name
+      image = var.container_image
+      cpu   = var.cpu
+      memory = var.memory
+      essential = true
+      portMappings = local.enable_alb ? [{
+        containerPort = var.service_port
+        hostPort      = var.service_port
+        protocol      = "tcp"
+      }] : []
+      environment = [for k, v in var.environment : {
+        name  = k
+        value = v
+      }]
+      secrets = [for s in var.secrets : {
+        name      = s.name
+        valueFrom = s.value_from
+      }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = var.log_group_name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = local.log_stream_prefix
+        }
+      }
+      healthCheck = var.container_health_check
+    }
+  ])
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count    = var.desired_count
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
+  enable_execute_command = var.enable_execute_command
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = var.security_group_ids
+    assign_public_ip = var.assign_public_ip
+  }
+
+  dynamic "load_balancer" {
+    for_each = local.enable_alb ? [local.target_group_arn] : []
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = local.container_name
+      container_port   = var.service_port
+    }
+  }
+
+  deployment_controller {
+    type = local.enable_cd ? "CODE_DEPLOY" : "ECS"
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_appautoscaling_target" "service" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_service.this.cluster}/${aws_ecs_service.this.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "${var.name}-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.service.resource_id
+  scalable_dimension = aws_appautoscaling_target.service.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.service.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = var.autoscale_cpu_target
+    scale_in_cooldown  = 120
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_appautoscaling_policy" "queue_depth" {
+  count              = var.sqs_queue_metric != null ? 1 : 0
+  name               = "${var.name}-queue"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.service.resource_id
+  scalable_dimension = aws_appautoscaling_target.service.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.service.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    customized_metric_specification {
+      metric_name = var.sqs_queue_metric.metric_name
+      namespace   = var.sqs_queue_metric.namespace
+      statistic   = var.sqs_queue_metric.statistic
+      unit        = var.sqs_queue_metric.unit
+      dimensions  = var.sqs_queue_metric.dimensions
+    }
+    target_value       = var.sqs_queue_metric.target_value
+    scale_in_cooldown  = 120
+    scale_out_cooldown = 60
+  }
+}
+
+resource "aws_codedeploy_app" "ecs" {
+  count = local.enable_cd ? 1 : 0
+  name  = "${var.name}-codedeploy"
+  compute_platform = "ECS"
+}
+
+resource "aws_codedeploy_deployment_group" "ecs" {
+  count                  = local.enable_cd ? 1 : 0
+  app_name               = aws_codedeploy_app.ecs[0].name
+  deployment_group_name  = "${var.name}-dg"
+  service_role_arn       = var.codedeploy_role_arn
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+
+  ecs_service {
+    cluster_name = var.cluster_name
+    service_name = aws_ecs_service.this.name
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [var.listener_arn]
+      }
+      test_traffic_route {
+        listener_arns = [var.listener_arn]
+      }
+      target_group {
+        name = aws_lb_target_group.blue[0].name
+      }
+      target_group {
+        name = aws_lb_target_group.green[0].name
+      }
+    }
+  }
+
+  alarm_configuration {
+    enabled = var.codedeploy_alarm_configuration.enabled
+    alarms  = var.codedeploy_alarm_configuration.alarm_names
+  }
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+}

--- a/infra/terraform/modules/ecs_service/outputs.tf
+++ b/infra/terraform/modules/ecs_service/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.this.name
+}
+
+output "target_group_arn" {
+  description = "Primary target group ARN"
+  value       = local.enable_alb ? aws_lb_target_group.blue[0].arn : null
+}
+
+output "task_definition_arn" {
+  description = "Task definition ARN"
+  value       = aws_ecs_task_definition.this.arn
+}

--- a/infra/terraform/modules/ecs_service/variables.tf
+++ b/infra/terraform/modules/ecs_service/variables.tf
@@ -1,0 +1,251 @@
+variable "name" {
+  type        = string
+  description = "Name of the ECS service"
+}
+
+variable "cluster_arn" {
+  type        = string
+  description = "ECS cluster ARN"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "ECS cluster name"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Container image URI"
+}
+
+variable "cpu" {
+  type        = number
+  description = "Task CPU units"
+}
+
+variable "memory" {
+  type        = number
+  description = "Task memory (MiB)"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired number of tasks"
+}
+
+variable "min_capacity" {
+  type        = number
+  description = "Minimum task count for scaling"
+}
+
+variable "max_capacity" {
+  type        = number
+  description = "Maximum task count for scaling"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnets for service networking"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security groups for service"
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  description = "Assign a public IP address"
+  default     = false
+}
+
+variable "listener_arn" {
+  type        = string
+  description = "ALB listener ARN"
+  default     = ""
+}
+
+variable "listener_priority" {
+  type        = number
+  description = "Listener rule priority"
+  default     = 200
+}
+
+variable "path_patterns" {
+  type        = list(string)
+  description = "Path patterns for listener rule"
+  default     = ["/*"]
+}
+
+variable "host_headers" {
+  type        = list(string)
+  description = "Host headers for listener rule"
+  default     = ["*"]
+}
+
+variable "health_check_path" {
+  type        = string
+  description = "Health check path"
+  default     = "/health"
+}
+
+variable "service_port" {
+  type        = number
+  description = "Container/service port"
+  default     = 80
+}
+
+variable "environment" {
+  type        = map(string)
+  description = "Environment variables"
+  default     = {}
+}
+
+variable "secrets" {
+  description = "Secrets for the container"
+  type = list(object({
+    name       = string
+    value_from = string
+  }))
+  default = []
+}
+
+variable "aws_region" {
+  description = "AWS region (for logs)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "Log group name"
+  type        = string
+}
+
+variable "log_group_arn" {
+  description = "Log group ARN for IAM permissions"
+  type        = string
+}
+
+variable "create_log_group" {
+  description = "Whether to manage log group"
+  type        = bool
+  default     = false
+}
+
+variable "log_retention_days" {
+  description = "Log retention in days"
+  type        = number
+  default     = 30
+}
+
+variable "log_kms_key_arn" {
+  description = "KMS key for log encryption"
+  type        = string
+  default     = null
+}
+
+variable "execution_role_arn" {
+  description = "Existing task execution role ARN"
+  type        = string
+  default     = null
+}
+
+variable "task_role_arn" {
+  description = "Existing task role ARN"
+  type        = string
+  default     = null
+}
+
+variable "task_additional_policy_statements" {
+  description = "Additional IAM policy statements"
+  type        = list(any)
+  default     = []
+}
+
+variable "secret_arns" {
+  description = "Secrets Manager ARNs for IAM"
+  type        = list(string)
+  default     = []
+}
+
+variable "sqs_queue_arns" {
+  description = "SQS queue ARNs for IAM"
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_bucket_arns" {
+  description = "S3 bucket ARNs for IAM"
+  type        = list(string)
+  default     = []
+}
+
+variable "sqs_queue_metric" {
+  description = "Custom metric config for queue-based scaling"
+  type = object({
+    metric_name  = string
+    namespace    = string
+    statistic    = string
+    unit         = string
+    dimensions   = list(object({
+      name  = string
+      value = string
+    }))
+    target_value = number
+  })
+  default = null
+}
+
+variable "enable_codedeploy" {
+  description = "Enable CodeDeploy blue/green"
+  type        = bool
+  default     = false
+}
+
+variable "codedeploy_role_arn" {
+  description = "Service role ARN for CodeDeploy"
+  type        = string
+  default     = null
+}
+
+variable "codedeploy_alarm_configuration" {
+  description = "CodeDeploy alarm configuration"
+  type = object({
+    enabled     = bool
+    alarm_names = list(string)
+  })
+  default = {
+    enabled     = false
+    alarm_names = []
+  }
+}
+
+variable "enable_execute_command" {
+  description = "Enable ECS exec"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "VPC ID for target groups"
+  type        = string
+}
+
+variable "container_health_check" {
+  description = "Container-level health check configuration"
+  type = object({
+    command     = list(string)
+    interval    = optional(number)
+    timeout     = optional(number)
+    retries     = optional(number)
+    startPeriod = optional(number)
+  })
+  default = {
+    command = ["CMD-SHELL", "curl -f http://localhost:80/health || exit 1"]
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/endpoints/main.tf
+++ b/infra/terraform/modules/endpoints/main.tf
@@ -1,0 +1,79 @@
+resource "aws_security_group" "endpoints" {
+  name        = "${var.name}-endpoints-sg"
+  description = "Interface endpoint access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = var.private_route_table_ids
+  tags              = var.tags
+}
+
+resource "aws_vpc_endpoint" "dkr" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags                = var.tags
+}
+
+resource "aws_vpc_endpoint" "api" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags                = var.tags
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags                = var.tags
+}
+
+resource "aws_vpc_endpoint" "secrets" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags                = var.tags
+}
+
+resource "aws_vpc_endpoint" "cloudwatch" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.monitoring"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags                = var.tags
+}

--- a/infra/terraform/modules/endpoints/outputs.tf
+++ b/infra/terraform/modules/endpoints/outputs.tf
@@ -1,0 +1,16 @@
+output "security_group_id" {
+  description = "Security group for interface endpoints"
+  value       = aws_security_group.endpoints.id
+}
+
+output "endpoint_ids" {
+  description = "Map of VPC endpoint IDs"
+  value = {
+    s3         = aws_vpc_endpoint.s3.id
+    ecr_dkr    = aws_vpc_endpoint.dkr.id
+    ecr_api    = aws_vpc_endpoint.api.id
+    logs       = aws_vpc_endpoint.logs.id
+    secrets    = aws_vpc_endpoint.secrets.id
+    cloudwatch = aws_vpc_endpoint.cloudwatch.id
+  }
+}

--- a/infra/terraform/modules/endpoints/variables.tf
+++ b/infra/terraform/modules/endpoints/variables.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  description = "Prefix for endpoint resources"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "private_route_table_ids" {
+  description = "Private route table IDs"
+  type        = list(string)
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for interface endpoints"
+  type        = list(string)
+}
+
+variable "allowed_cidrs" {
+  description = "CIDR blocks allowed to reach endpoints"
+  type        = list(string)
+  default     = ["10.0.0.0/8"]
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/iam_roles/main.tf
+++ b/infra/terraform/modules/iam_roles/main.tf
@@ -1,0 +1,186 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+}
+
+resource "aws_iam_role" "ecs_execution" {
+  name = "${local.name_prefix}-ecs-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${local.name_prefix}-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "ecs_task" {
+  name = "${local.name_prefix}-ecs-policy"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid    = "AllowLogs"
+        Effect = "Allow"
+        Action = ["logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = var.log_group_arns
+      },
+      {
+        Sid    = "AllowSecrets"
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+        Resource = var.secret_arns
+      },
+      {
+        Sid    = "AllowSQS"
+        Effect = "Allow"
+        Action = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes", "sqs:SendMessage", "sqs:ChangeMessageVisibility"]
+        Resource = var.sqs_queue_arns
+      },
+      {
+        Sid    = "AllowS3ReadWrite"
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:PutObject"]
+        Resource = [for bucket in var.s3_bucket_arns : "${bucket}/*"]
+      },
+      {
+        Sid    = "AllowS3List"
+        Effect = "Allow"
+        Action = ["s3:ListBucket"]
+        Resource = var.s3_bucket_arns
+      }
+    ], var.additional_task_statements)
+  })
+}
+
+resource "aws_iam_role" "github" {
+  name = "${local.name_prefix}-github-oidc"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:sub" = "repo:${var.github_org}/${var.github_repo}:ref:refs/heads/*"
+        },
+        StringLike = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "github" {
+  name = "${local.name_prefix}-github-policy"
+  role = aws_iam_role.github.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sts:AssumeRole",
+          "iam:PassRole"
+        ]
+        Resource = [aws_iam_role.ecs_task.arn, aws_iam_role.ecs_execution.arn, aws_iam_role.codedeploy.arn]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecs:DescribeServices",
+          "ecs:UpdateService",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
+          "ecs:ListServices",
+          "ecs:DescribeClusters"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "codedeploy:CreateDeployment",
+          "codedeploy:StopDeployment",
+          "codedeploy:GetDeployment",
+          "codedeploy:GetDeploymentGroup",
+          "codedeploy:GetApplication"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = ["logs:DescribeLogGroups", "logs:DescribeLogStreams"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "codedeploy" {
+  name = "${local.name_prefix}-codedeploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "codedeploy.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy" {
+  role       = aws_iam_role.codedeploy.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForECS"
+}
+
+data "aws_caller_identity" "current" {}

--- a/infra/terraform/modules/iam_roles/outputs.tf
+++ b/infra/terraform/modules/iam_roles/outputs.tf
@@ -1,0 +1,19 @@
+output "task_role_arn" {
+  description = "ECS task role ARN"
+  value       = aws_iam_role.ecs_task.arn
+}
+
+output "execution_role_arn" {
+  description = "ECS execution role ARN"
+  value       = aws_iam_role.ecs_execution.arn
+}
+
+output "github_oidc_role_arn" {
+  description = "GitHub Actions OIDC role ARN"
+  value       = aws_iam_role.github.arn
+}
+
+output "codedeploy_role_arn" {
+  description = "CodeDeploy service role ARN"
+  value       = aws_iam_role.codedeploy.arn
+}

--- a/infra/terraform/modules/iam_roles/variables.tf
+++ b/infra/terraform/modules/iam_roles/variables.tf
@@ -1,0 +1,56 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+  default     = "jotiq"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "log_group_arns" {
+  description = "CloudWatch log group ARNs"
+  type        = list(string)
+  default     = []
+}
+
+variable "secret_arns" {
+  description = "Secrets Manager ARNs"
+  type        = list(string)
+  default     = []
+}
+
+variable "sqs_queue_arns" {
+  description = "SQS queue ARNs"
+  type        = list(string)
+  default     = []
+}
+
+variable "s3_bucket_arns" {
+  description = "S3 bucket ARNs"
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_task_statements" {
+  description = "Additional IAM statements for task role"
+  type        = list(any)
+  default     = []
+}
+
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/observability/main.tf
+++ b/infra/terraform/modules/observability/main.tf
@@ -1,0 +1,218 @@
+resource "aws_cloudwatch_log_group" "service" {
+  for_each = { for svc in var.services : svc.name => svc }
+
+  name              = "/aws/ecs/${var.project}/${var.environment}/${each.value.name}"
+  retention_in_days = each.value.retention_in_days
+  kms_key_id        = var.log_kms_key_arn
+  tags              = var.tags
+}
+
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project}-${var.environment}-alerts"
+  kms_master_key_id = var.sns_kms_key_arn
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  alarm_name          = "${var.project}-${var.environment}-alb-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_description   = "High rate of 5XX on ALB"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_latency" {
+  alarm_name          = "${var.project}-${var.environment}-alb-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.alb_latency_threshold
+  alarm_description   = "High target response time"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu" {
+  for_each = { for svc in var.services : svc.name => svc }
+
+  alarm_name          = "${var.project}-${var.environment}-${each.key}-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = each.value.cpu_threshold
+  alarm_description   = "High CPU for ${each.key}"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = each.value.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory" {
+  for_each = { for svc in var.services : svc.name => svc }
+
+  alarm_name          = "${var.project}-${var.environment}-${each.key}-memory"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = each.value.memory_threshold
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  alarm_description   = "High memory for ${each.key}"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = each.value.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs_depth" {
+  alarm_name          = "${var.project}-${var.environment}-sqs-depth"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = var.sqs_max_messages
+  alarm_description   = "Queue depth high"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    QueueName = var.sqs_queue_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sqs_age" {
+  alarm_name          = "${var.project}-${var.environment}-sqs-age"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = var.sqs_max_age_seconds
+  alarm_description   = "Queue age high"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    QueueName = var.sqs_queue_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ses_bounce" {
+  alarm_name          = "${var.project}-${var.environment}-ses-bounce"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Reputation.BounceRate"
+  namespace           = "AWS/SES"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.ses_bounce_threshold
+  alarm_description   = "High SES bounce rate"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    Identity = var.ses_identity
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ses_complaint" {
+  alarm_name          = "${var.project}-${var.environment}-ses-complaint"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Reputation.ComplaintRate"
+  namespace           = "AWS/SES"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.ses_complaint_threshold
+  alarm_description   = "High SES complaint rate"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    Identity = var.ses_identity
+  }
+}
+
+locals {
+  dashboard_widgets = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        width = 12
+        height = 6
+        properties = {
+          title = "ALB 5XX & Latency"
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", var.alb_arn_suffix],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", var.alb_arn_suffix]
+          ]
+          period = 300
+          stat   = "Average"
+        }
+      },
+      {
+        type = "metric"
+        width = 12
+        height = 6
+        properties = {
+          title = "SQS Depth & Age"
+          metrics = [
+            ["AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", var.sqs_queue_name],
+            ["AWS/SQS", "ApproximateAgeOfOldestMessage", "QueueName", var.sqs_queue_name]
+          ]
+          period = 300
+          stat   = "Average"
+        }
+      },
+      {
+        type = "metric"
+        width = 24
+        height = 6
+        properties = {
+          title = "ECS CPU"
+          metrics = [for svc in var.services : ["AWS/ECS", "CPUUtilization", "ClusterName", var.ecs_cluster_name, "ServiceName", svc.name]]
+          period = 300
+          stat   = "Average"
+        }
+      },
+      {
+        type = "metric"
+        width = 24
+        height = 6
+        properties = {
+          title = "ECS Memory"
+          metrics = [for svc in var.services : ["AWS/ECS", "MemoryUtilization", "ClusterName", var.ecs_cluster_name, "ServiceName", svc.name]]
+          period = 300
+          stat   = "Average"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_dashboard" "this" {
+  dashboard_name = "${var.project}-${var.environment}-overview"
+  dashboard_body = local.dashboard_widgets
+}

--- a/infra/terraform/modules/observability/outputs.tf
+++ b/infra/terraform/modules/observability/outputs.tf
@@ -1,0 +1,29 @@
+output "log_group_names" {
+  description = "Map of log group names"
+  value       = { for name, group in aws_cloudwatch_log_group.service : name => group.name }
+}
+
+output "log_group_arns" {
+  description = "Map of log group ARNs"
+  value       = { for name, group in aws_cloudwatch_log_group.service : name => group.arn }
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alerts"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "dashboard_name" {
+  description = "CloudWatch dashboard name"
+  value       = aws_cloudwatch_dashboard.this.dashboard_name
+}
+
+output "alb_5xx_alarm_name" {
+  description = "ALB 5XX alarm name"
+  value       = aws_cloudwatch_metric_alarm.alb_5xx.alarm_name
+}
+
+output "alb_latency_alarm_name" {
+  description = "ALB latency alarm name"
+  value       = aws_cloudwatch_metric_alarm.alb_latency.alarm_name
+}

--- a/infra/terraform/modules/observability/variables.tf
+++ b/infra/terraform/modules/observability/variables.tf
@@ -1,0 +1,88 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+  default     = "jotiq"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "services" {
+  description = "List of ECS services"
+  type = list(object({
+    name               = string
+    retention_in_days  = number
+    cpu_threshold      = number
+    memory_threshold   = number
+  }))
+}
+
+variable "log_kms_key_arn" {
+  description = "KMS key for log encryption"
+  type        = string
+  default     = null
+}
+
+variable "sns_kms_key_arn" {
+  description = "KMS key for SNS"
+  type        = string
+  default     = null
+}
+
+variable "alb_arn_suffix" {
+  description = "ALB ARN suffix"
+  type        = string
+}
+
+variable "alb_latency_threshold" {
+  description = "ALB latency threshold"
+  type        = number
+  default     = 0.5
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}
+
+variable "sqs_queue_name" {
+  description = "Primary SQS queue name"
+  type        = string
+}
+
+variable "sqs_max_messages" {
+  description = "Max visible messages before alarm"
+  type        = number
+  default     = 100
+}
+
+variable "sqs_max_age_seconds" {
+  description = "Max age of oldest message"
+  type        = number
+  default     = 300
+}
+
+variable "ses_identity" {
+  description = "SES identity"
+  type        = string
+}
+
+variable "ses_bounce_threshold" {
+  description = "SES bounce rate threshold"
+  type        = number
+  default     = 5
+}
+
+variable "ses_complaint_threshold" {
+  description = "SES complaint rate threshold"
+  type        = number
+  default     = 1
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/route53/main.tf
+++ b/infra/terraform/modules/route53/main.tf
@@ -1,0 +1,56 @@
+locals {
+  zone_id = var.create_zone ? aws_route53_zone.this[0].zone_id : var.hosted_zone_id
+}
+
+resource "aws_route53_zone" "this" {
+  count = var.create_zone ? 1 : 0
+  name  = var.zone_name
+  comment = "Hosted zone for ${var.zone_name}"
+  tags   = var.tags
+}
+
+resource "aws_route53_record" "api" {
+  zone_id = local.zone_id
+  name    = var.api_record
+  type    = "A"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = local.zone_id
+  name    = var.app_record
+  type    = "A"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "assets" {
+  zone_id = local.zone_id
+  name    = var.assets_record
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "ses_records" {
+  for_each = var.ses_records
+
+  zone_id = local.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = each.value.ttl
+  records = each.value.records
+}

--- a/infra/terraform/modules/route53/outputs.tf
+++ b/infra/terraform/modules/route53/outputs.tf
@@ -1,0 +1,4 @@
+output "hosted_zone_id" {
+  description = "Hosted zone ID used for records"
+  value       = local.zone_id
+}

--- a/infra/terraform/modules/route53/variables.tf
+++ b/infra/terraform/modules/route53/variables.tf
@@ -1,0 +1,73 @@
+variable "create_zone" {
+  description = "Whether to create a new hosted zone"
+  type        = bool
+  default     = false
+}
+
+variable "zone_name" {
+  description = "DNS zone name"
+  type        = string
+  default     = "jotiq.com"
+}
+
+variable "hosted_zone_id" {
+  description = "Existing hosted zone ID"
+  type        = string
+  default     = null
+}
+
+variable "api_record" {
+  description = "API record name"
+  type        = string
+  default     = "api.jotiq.com"
+}
+
+variable "app_record" {
+  description = "App record name"
+  type        = string
+  default     = "app.jotiq.com"
+}
+
+variable "assets_record" {
+  description = "Assets record name"
+  type        = string
+  default     = "assets.jotiq.com"
+}
+
+variable "alb_dns_name" {
+  description = "ALB DNS name"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "ALB hosted zone ID"
+  type        = string
+}
+
+variable "cloudfront_domain_name" {
+  description = "CloudFront domain name"
+  type        = string
+}
+
+variable "cloudfront_hosted_zone_id" {
+  description = "CloudFront hosted zone ID"
+  type        = string
+  default     = "Z2FDTNDATAQYW2"
+}
+
+variable "ses_records" {
+  description = "Additional SES verification records"
+  type = map(object({
+    name    = string
+    type    = string
+    ttl     = number
+    records = list(string)
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/s3_bucket/main.tf
+++ b/infra/terraform/modules/s3_bucket/main.tf
@@ -1,0 +1,79 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.enable_versioning ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_logging" "this" {
+  count  = var.log_bucket == null ? 0 : 1
+  bucket = aws_s3_bucket.this.id
+
+  target_bucket = var.log_bucket
+  target_prefix = var.log_prefix
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "transition-logs"
+    status = "Enabled"
+
+    transition {
+      days          = 180
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 90
+      storage_class   = "GLACIER"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront" {
+  count  = var.cloudfront_access_identity == null ? 0 : 1
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontAccess"
+        Effect    = "Allow"
+        Principal = {
+          AWS = var.cloudfront_access_identity
+        }
+        Action   = ["s3:GetObject"]
+        Resource = "${aws_s3_bucket.this.arn}/*"
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/s3_bucket/outputs.tf
+++ b/infra/terraform/modules/s3_bucket/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_id" {
+  description = "Bucket ID"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "Bucket ARN"
+  value       = aws_s3_bucket.this.arn
+}

--- a/infra/terraform/modules/s3_bucket/variables.tf
+++ b/infra/terraform/modules/s3_bucket/variables.tf
@@ -1,0 +1,39 @@
+variable "name" {
+  description = "Bucket name"
+  type        = string
+}
+
+variable "enable_versioning" {
+  description = "Enable versioning"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN"
+  type        = string
+}
+
+variable "log_bucket" {
+  description = "Log destination bucket"
+  type        = string
+  default     = null
+}
+
+variable "log_prefix" {
+  description = "Log prefix"
+  type        = string
+  default     = "logs"
+}
+
+variable "cloudfront_access_identity" {
+  description = "CloudFront origin access identity ARN"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -1,0 +1,36 @@
+resource "aws_kms_key" "this" {
+  description         = "Secrets Manager encryption key for ${var.project}-${var.environment}"
+  enable_key_rotation = true
+  deletion_window_in_days = 10
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.project}-${var.environment}-secrets"
+  target_key_id = aws_kms_key.this.key_id
+}
+
+locals {
+  secrets = {
+    MONGODB_URI   = var.mongodb_uri_placeholder
+    JWT_SECRET    = var.jwt_secret_placeholder
+    SES_SMTP_USER = var.ses_smtp_user_placeholder
+    SES_SMTP_PASS = var.ses_smtp_pass_placeholder
+  }
+}
+
+resource "aws_secretsmanager_secret" "this" {
+  for_each = local.secrets
+
+  name                    = "${var.project}/${var.environment}/${each.key}"
+  kms_key_id              = aws_kms_key.this.arn
+  recovery_window_in_days = var.recovery_window_days
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  for_each = local.secrets
+
+  secret_id     = aws_secretsmanager_secret.this[each.key].id
+  secret_string = each.value
+}

--- a/infra/terraform/modules/secrets/outputs.tf
+++ b/infra/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,9 @@
+output "kms_key_arn" {
+  description = "KMS key ARN"
+  value       = aws_kms_key.this.arn
+}
+
+output "secret_arns" {
+  description = "Map of secret ARNs"
+  value       = { for k, v in aws_secretsmanager_secret.this : k => v.arn }
+}

--- a/infra/terraform/modules/secrets/variables.tf
+++ b/infra/terraform/modules/secrets/variables.tf
@@ -1,0 +1,46 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+  default     = "jotiq"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "mongodb_uri_placeholder" {
+  description = "Placeholder MongoDB URI"
+  type        = string
+  default     = "mongodb+srv://readonly:password@cluster.jotiq.mongodb.net/app"
+}
+
+variable "jwt_secret_placeholder" {
+  description = "Placeholder JWT secret"
+  type        = string
+  default     = "change-me-jwt-secret"
+}
+
+variable "ses_smtp_user_placeholder" {
+  description = "Placeholder SES SMTP user"
+  type        = string
+  default     = "AKIAIOSFODNN7EXAMPLE"
+}
+
+variable "ses_smtp_pass_placeholder" {
+  description = "Placeholder SES SMTP password"
+  type        = string
+  default     = "super-secret-password"
+}
+
+variable "recovery_window_days" {
+  description = "Secret recovery window"
+  type        = number
+  default     = 7
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ses_domain/main.tf
+++ b/infra/terraform/modules/ses_domain/main.tf
@@ -1,0 +1,61 @@
+resource "aws_ses_domain_identity" "this" {
+  domain = var.domain
+}
+
+resource "aws_ses_domain_dkim" "this" {
+  domain = aws_ses_domain_identity.this.domain
+}
+
+resource "aws_route53_record" "verification" {
+  count  = var.create_route53_records ? 1 : 0
+  name    = "_amazonses.${aws_ses_domain_identity.this.domain}"
+  type    = "TXT"
+  zone_id = var.hosted_zone_id
+  ttl     = 600
+  records = [aws_ses_domain_identity.this.verification_token]
+}
+
+resource "aws_route53_record" "dkim" {
+  count   = var.create_route53_records ? 3 : 0
+  name    = "${aws_ses_domain_dkim.this.dkim_tokens[count.index]}._domainkey.${aws_ses_domain_identity.this.domain}"
+  type    = "CNAME"
+  zone_id = var.hosted_zone_id
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.this.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "spf" {
+  count  = var.create_route53_records ? 1 : 0
+  name    = var.domain
+  type    = "TXT"
+  zone_id = var.hosted_zone_id
+  ttl     = 600
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+resource "aws_ses_identity_notification_topic" "bounce" {
+  identity = aws_ses_domain_identity.this.arn
+  notification_type = "Bounce"
+  topic_arn = var.sns_topic_arn
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "complaint" {
+  identity = aws_ses_domain_identity.this.arn
+  notification_type = "Complaint"
+  topic_arn = var.sns_topic_arn
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "delivery" {
+  identity = aws_ses_domain_identity.this.arn
+  notification_type = "Delivery"
+  topic_arn = var.sns_topic_arn
+  include_original_headers = false
+}
+
+resource "aws_ses_domain_identity_verification" "this" {
+  count      = var.create_route53_records ? 1 : 0
+  domain     = aws_ses_domain_identity.this.domain
+  depends_on = var.create_route53_records ? [aws_route53_record.verification[0]] : []
+}

--- a/infra/terraform/modules/ses_domain/outputs.tf
+++ b/infra/terraform/modules/ses_domain/outputs.tf
@@ -1,0 +1,14 @@
+output "identity_arn" {
+  description = "SES domain identity ARN"
+  value       = aws_ses_domain_identity.this.arn
+}
+
+output "dkim_tokens" {
+  description = "DKIM tokens"
+  value       = aws_ses_domain_dkim.this.dkim_tokens
+}
+
+output "verification_token" {
+  description = "SES verification token"
+  value       = aws_ses_domain_identity.this.verification_token
+}

--- a/infra/terraform/modules/ses_domain/variables.tf
+++ b/infra/terraform/modules/ses_domain/variables.tf
@@ -1,0 +1,26 @@
+variable "domain" {
+  description = "Domain to verify"
+  type        = string
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID"
+  type        = string
+}
+
+variable "sns_topic_arn" {
+  description = "SNS topic ARN for feedback"
+  type        = string
+}
+
+variable "create_route53_records" {
+  description = "Whether to create Route53 records within this module"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/sqs_queue/main.tf
+++ b/infra/terraform/modules/sqs_queue/main.tf
@@ -1,0 +1,23 @@
+resource "aws_sqs_queue" "dlq" {
+  count = var.create_dlq ? 1 : 0
+
+  name                       = "${var.name}-dlq"
+  message_retention_seconds  = var.dlq_retention_seconds
+  kms_master_key_id          = var.kms_key_arn
+  visibility_timeout_seconds = var.visibility_timeout
+  tags                       = var.tags
+}
+
+resource "aws_sqs_queue" "this" {
+  name                              = var.name
+  visibility_timeout_seconds        = var.visibility_timeout
+  message_retention_seconds         = var.retention_seconds
+  kms_master_key_id                 = var.kms_key_arn
+  receive_wait_time_seconds         = var.receive_wait_seconds
+  sqs_managed_sse_enabled           = false
+  redrive_policy = var.create_dlq ? jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq[0].arn
+    maxReceiveCount     = var.max_receive_count
+  }) : null
+  tags = var.tags
+}

--- a/infra/terraform/modules/sqs_queue/outputs.tf
+++ b/infra/terraform/modules/sqs_queue/outputs.tf
@@ -1,0 +1,19 @@
+output "queue_url" {
+  description = "Queue URL"
+  value       = aws_sqs_queue.this.id
+}
+
+output "queue_arn" {
+  description = "Queue ARN"
+  value       = aws_sqs_queue.this.arn
+}
+
+output "dlq_arn" {
+  description = "DLQ ARN"
+  value       = var.create_dlq ? aws_sqs_queue.dlq[0].arn : null
+}
+
+output "queue_name" {
+  description = "Queue name"
+  value       = aws_sqs_queue.this.name
+}

--- a/infra/terraform/modules/sqs_queue/variables.tf
+++ b/infra/terraform/modules/sqs_queue/variables.tf
@@ -1,0 +1,51 @@
+variable "name" {
+  description = "Queue name"
+  type        = string
+}
+
+variable "visibility_timeout" {
+  description = "Visibility timeout"
+  type        = number
+  default     = 30
+}
+
+variable "retention_seconds" {
+  description = "Message retention"
+  type        = number
+  default     = 345600
+}
+
+variable "receive_wait_seconds" {
+  description = "Long polling wait time"
+  type        = number
+  default     = 10
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN"
+  type        = string
+}
+
+variable "create_dlq" {
+  description = "Create DLQ"
+  type        = bool
+  default     = true
+}
+
+variable "max_receive_count" {
+  description = "Max receive count before DLQ"
+  type        = number
+  default     = 5
+}
+
+variable "dlq_retention_seconds" {
+  description = "DLQ retention"
+  type        = number
+  default     = 1209600
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,105 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.azs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.cidr_block, 4, count.index)
+  map_public_ip_on_launch = true
+  availability_zone       = var.azs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-${count.index + 1}",
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.azs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.cidr_block, 4, count.index + length(var.azs))
+  availability_zone = var.azs[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${count.index + 1}",
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  count = var.enable_nat ? length(var.azs) : 0
+  vpc   = true
+
+  depends_on = [aws_internet_gateway.this]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat-eip-${count.index + 1}"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat ? length(var.azs) : 0
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.azs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count = length(var.azs)
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-rt-${count.index + 1}"
+  })
+}
+
+resource "aws_route" "private_default" {
+  count = var.enable_nat ? length(var.azs) : 0
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[count.index].id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.azs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "public_route_table_id" {
+  description = "Public route table ID"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "Private route table IDs"
+  value       = aws_route_table.private[*].id
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "Prefix for VPC resources"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "enable_nat" {
+  description = "Whether to provision NAT gateways"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add reusable Terraform modules for networking, compute, storage, secrets, messaging, and DNS integrations supporting the JOTIQ platform
- compose dev/staging/prod environments that provision VPC networking, ECS services (API, web, worker), MongoDB secrets, SES, SQS, CloudFront, Route53, and CodeDeploy-driven blue/green deployments
- deliver observability assets (CloudWatch log groups, alarms, dashboards) plus Terraform/ECS GitHub Actions pipelines using OIDC-based authentication

## Testing
- not run (Terraform and Docker tooling unavailable in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2d4c545288332911f8142da5d065d